### PR TITLE
Adding SQL to enable snapshot event splitting in Fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ NOTE: This lab has not been hardened in any way and runs with default vagrant cr
 
 ## Requirements
 * 55GB+ of free disk space
+* 16GB+ of RAM
 * Packer 1.0.0 or newer
 * Vagrant 1.9.2 or newer
 * Virtualbox or VMWare Fusion/Workstation

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -61,6 +61,8 @@ sed -i 's/ -it//g' demo.sh
 ./demo.sh up simple
 # Set the enrollment secret to match what we deploy to Windows hosts
 docker run --rm --network=kolidequickstart_default mysql:5.7 mysql -h mysql -u kolide --password=kolide -e 'update app_configs set osquery_enroll_secret = "enrollmentsecret" where id=1;' --batch kolide
+# Set snapshot events to be split into multiple events
+docker run --rm --network=kolidequickstart_default mysql:5.7 mysql -h mysql -u kolide --password=kolide -e 'insert into options (name, type, value) values ("logger_snapshot_event_type", 2, "true");' --batch kolide
 echo "Updated enrollment secret"
 cd /home/vagrant
 


### PR DESCRIPTION
By default, osquery combines multiple events into a single log event for snapshot logging. This change enables a configuration option that ensures each snapshot event contains one event per log. 

More info here: https://github.com/facebook/osquery/issues/3701