### PR TITLE
Adding Caldera to DetectionLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ NOTE: This lab has not been hardened in any way and runs with default vagrant cr
 * Powershell transcript logging is enabled. All logs are saved to `\\wef\pslogs`
 * osquery comes installed on each host and is pre-configured to connect to a [Fleet](https://kolide.co/fleet) server via TLS. Fleet is preconfigured with the configuration from [Palantir's osquery Configuration](https://github.com/palantir/osquery-configuration)
 * Sysmon is installed and configured using SwiftOnSecurity’s open-sourced configuration
+* Mitre's [Caldera](https://github.com/mitre/caldera) server is built on the logger host and the Caldera agent gets pre-installed on all Windows hosts
 * All autostart items are logged to Windows Event Logs via [AutorunsToWinEventLog](https://github.com/palantir/windows-event-forwarding/tree/master/AutorunsToWinEventLog)
 * SMBv1 Auditing is enabled
 
@@ -84,8 +85,9 @@ Vagrant commands must be run from the "Vagrant" folder.
 ## Lab Information
 * Domain Name: windomain.local
 * Admininstrator login: vagrant:vagrant
-* Fleet login: admin:admin123#
-* Splunk login: admin:changeme
+* Fleet login: https://192.168.38.5:8412 - admin:admin123#
+* Splunk login: https://192.168.38.5:8000 - admin:changeme
+* Caldera login: https://192.168.38.5:8888 - admin:caldera
 
 ## Lab Hosts
 * DC - Windows 2016 Domain Controller
@@ -113,6 +115,7 @@ Vagrant commands must be run from the "Vagrant" folder.
 * Logger - Ubuntu 16.04
   * Splunk Enterprise
   * Fleet osquery Manager
+  * Mitre's Caldera Server
 
 ## Splunk Indexes
 Index Name | Description
@@ -127,6 +130,7 @@ wineventlog | Windows Event Logs
   * Sysmon
   * osquery
   * AutorunsToWinEventLog
+  * Caldera Agent
   * Process Monitor
   * Process Explorer
   * PsExec
@@ -193,6 +197,7 @@ A sizable percentage of this code was borrowed and adapted from [Stefan Scherer]
 * [Splunk](https://www.splunk.com)
 * [osquery](https://osquery.io)
 * [Fleet](https://kolide.co/fleet)
+* [Caldera](https://github.com/mitre/caldera)
 * [Windows Event Forwarding for Network Defense](https://medium.com/@palantir/windows-event-forwarding-for-network-defense-cb208d5ff86f)
 * [palantir/windows-event-forwarding](http://github.com/palantir/windows-event-forwarding)
 * [osquery Across the Enterprise](https://medium.com/@palantir/osquery-across-the-enterprise-3c3c9d13ec55)

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -46,6 +46,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", path: "scripts/install-inputsconf.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-utilities.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-osquery.ps1", privileged: true
+    cfg.vm.provision "shell", path: "scripts/install-caldera-agent.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-sysinternals.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/configure-ou.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/configure-wef-gpo.ps1", privileged: true
@@ -89,6 +90,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", path: "scripts/install-windows_ta.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-utilities.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-osquery.ps1", privileged: true
+    cfg.vm.provision "shell", path: "scripts/install-caldera-agent.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-inputsconf.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-sysinternals.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/configure-pslogstranscriptsshare.ps1", privileged: true
@@ -128,6 +130,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", path: "scripts/install-splunkuf.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-utilities.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-osquery.ps1", privileged: true
+    cfg.vm.provision "shell", path: "scripts/install-caldera-agent.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-inputsconf.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-sysinternals.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-autorunstowineventlog.ps1", privileged: true

--- a/Vagrant/resources/caldera/caldera.service
+++ b/Vagrant/resources/caldera/caldera.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=My Script Service
+After=multi-user.target
+
+[Service]
+Type=idle
+WorkingDirectory=/home/vagrant/caldera/caldera
+ExecStart=/usr/bin/python3 caldera.py
+
+[Install]
+WantedBy=multi-user.target

--- a/Vagrant/resources/caldera/mongod.service
+++ b/Vagrant/resources/caldera/mongod.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=High-performance, schema-free document-oriented database
+After=network.target
+Documentation=https://docs.mongodb.org/manual
+
+[Service]
+User=mongodb
+Group=mongodb
+ExecStart=/usr/bin/mongod --quiet --config /etc/mongod.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/Vagrant/resources/caldera/sslproto.patch
+++ b/Vagrant/resources/caldera/sslproto.patch
@@ -1,0 +1,14 @@
+--- sslproto.py	2018-01-17 08:00:50.567571454 +0000
++++ sslproto.py.new	2018-01-17 08:03:31.996275969 +0000
+@@ -533,8 +533,10 @@
+     def _get_extra_info(self, name, default=None):
+         if name in self._extra:
+             return self._extra[name]
+-        else:
++        elif self._transport is not None:
+             return self._transport.get_extra_info(name, default)
++        else:
++            return default
+
+     def _start_shutdown(self):
+         if self._in_shutdown:

--- a/Vagrant/scripts/install-caldera-agent.ps1
+++ b/Vagrant/scripts/install-caldera-agent.ps1
@@ -1,0 +1,26 @@
+# Purpose: Installs the Caldera agent on the host
+
+# Add /etc/hosts entry
+Add-Content "c:\windows\system32\drivers\etc\hosts" "        192.168.38.5    logger"
+
+# Make the directory
+New-Item "c:\Program Files\cagent" -type directory
+
+# Install Visual Studio 2015 C++ Redistributable
+choco install -y vcredist2015
+
+# Download cagent and start the service
+If (-not (Test-Path "C:\Program Files\cagent\cagent.exe")) {
+  Write-Host "Downloading Caldera Agent (cagent.exe)"
+  $cagentPath = "C:\Program Files\cagent\cagent.exe"
+  $cagentConfPath = "C:\Program Files\cagent\conf.yml"
+  (New-Object System.Net.WebClient).DownloadFile('https://github.com/mitre/caldera-agent/releases/download/v0.1.0/cagent.exe', $cagentPath)
+  # Ignore SSL warning for conf file download
+  # https://stackoverflow.com/questions/34331206/ignore-ssl-warning-with-powershell-downloadstring
+  [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ;(New-Object System.Net.WebClient).DownloadFile('https://logger:8888/conf.yml', $cagentConfPath)
+  Start-Process -FilePath $cagentPath -ArgumentList '--startup', 'auto', 'install' -Wait
+  Start-Process -FilePath $cagentPath -ArgumentList 'start' -Wait
+} Else {
+  Write-Host "Caldera Agent is already installed. Moving on."
+}
+Write-Host "Cagent installation complete!"

--- a/Vagrant/scripts/install-sysinternals.ps1
+++ b/Vagrant/scripts/install-sysinternals.ps1
@@ -38,6 +38,9 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/SwiftOnSecurity/sysmon
 # Convert Sysmon config schema from 3.30 to 4.0 per GitHub Issue #38
 (Get-Content $sysmonConfigPath) -replace 'schemaversion="3.30"', 'schemaversion="4.00"' | Set-Content $sysmonConfigPath
 
+# Convert Schema from 3.30 to 4.0 per GitHub Issue #38
+(Get-Content $sysmonConfigPath) -replace 'schemaversion="3.30"', 'schemaversion="4.00"' | Set-Content $sysmonConfigPath
+
 # Startup Sysmon
 Write-Host "Starting Sysmon..."
 Start-Process -FilePath "$sysmonDir\Sysmon64.exe" -ArgumentList "-accepteula -i $sysmonConfigPath"

--- a/Vagrant/scripts/join-domain.ps1
+++ b/Vagrant/scripts/join-domain.ps1
@@ -18,7 +18,7 @@ $DomainCred = New-Object System.Management.Automation.PSCredential $user, $pass
 If ($hostname -eq "wef") {
   Add-Computer -DomainName "windomain.local" -credential $DomainCred -OUPath "ou=Servers,dc=windomain,dc=local" -PassThru
 } ElseIf ($hostname -eq "win10") {
-  Write-Host "Adding Win10 to the domain. Sometimes this step times out when using VMWare. If that happens, just run 'vagrant reload win10 --provision'" #debug
+  Write-Host "Adding Win10 to the domain. Sometimes this step times out. If that happens, just run 'vagrant reload win10 --provision'" #debug
   Add-Computer -DomainName "windomain.local" -credential $DomainCred -OUPath "ou=Workstations,dc=windomain,dc=local"
 } Else {
   Add-Computer -DomainName "windomain.local" -credential $DomainCred -PassThru


### PR DESCRIPTION
This PR add support for building Mitre's [Caldera](https://github.com/mitre/caldera) server on the logger host and installs Caldera agents on all 3 Windows hosts. This should allow users to generate attack simulations quickly and easily, rather than having to use an external host to conduct attacks.

For more information, please visit the documentation for Caldera: https://caldera.readthedocs.io/