### PR TITLE
Configure mongod and caldera services to start at boot

### DIFF
--- a/Packer/scripts/MakeWindows10GreatAgain.ps1
+++ b/Packer/scripts/MakeWindows10GreatAgain.ps1
@@ -14,8 +14,3 @@ if ($onedrive) {
   taskkill /f /im OneDrive.exe
 }
 c:\Windows\SysWOW64\OneDriveSetup.exe /uninstall
-
-# Disable SMBv1
-Write-Host "Disabling SMBv1"
-Set-SmbServerConfiguration -EnableSMB1Protocol $false -Confirm:$false
-

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -143,7 +143,9 @@ cp /vagrant/resources/caldera/caldera.service /lib/systemd/system/caldera.servic
 echo 'replication:
    replSetName: caldera' >> /etc/mongod.conf
 service mongod start
+systemctl enable mongod.service
 cd /home/vagrant/caldera
 mkdir -p dep/crater/crater
 wget https://github.com/mitre/caldera-crater/releases/download/v0.1.0/CraterMainWin8up.exe -O /home/vagrant/caldera/dep/crater/crater/CraterMain.exe
 service caldera start
+systemctl enable caldera.service

--- a/Vagrant/scripts/install-utilities.ps1
+++ b/Vagrant/scripts/install-utilities.ps1
@@ -19,7 +19,13 @@ apm install language-powershell
 apm install language-batch
 apm install language-docker
 
-# Purpose: Downloads and unzips a copy of the Palantir osquery Github Repo. These configs are added to the Fleet server in bootstrap.sh.
-$mimikatzRepoPath = 'C:\Users\vagrant\AppData\Local\Temp\osquery-Master.zip'
-Invoke-WebRequest -Uri "https://github.com/gentilkiwi/mimikatz/releases/download/2.1.1-20171203/mimikatz_trunk.zip" -OutFile $mimikatzRepoPath
+# Disable Windows Defender realtime scanning before downloading Mimikatz
+set-MpPreference -DisableRealtimeMonitoring $true
+
+# Purpose: Downloads and unzips a copy of the latest Mimikatz trunk
+Write-Host Determining latest release of Mimikatz...
+$tag = (Invoke-WebRequest "https://api.github.com/repos/gentilkiwi/mimikatz/releases" -UseBasicParsing | ConvertFrom-Json)[0].tag_name
+$mimikatzDownloadUrl = "https://github.com/gentilkiwi/mimikatz/releases/download/$tag/mimikatz_trunk.zip"
+$mimikatzRepoPath = 'C:\Users\vagrant\AppData\Local\Temp\mimikatz_trunk.zip'
+Invoke-WebRequest -Uri "$mimikatzDownloadUrl" -OutFile $mimikatzRepoPath
 Expand-Archive -path "$mimikatzRepoPath" -destinationpath 'c:\Tools\Mimikatz' -Force


### PR DESCRIPTION
- Configure mongod and caldera services to start at boot (#51)
- Fix the mimikatz download script (#52)
- Remove code that disabled SMBv1 during the packer build for Win10