### PR TITLE
Prevent Windows Defender from blocking CALDERA

### DIFF
--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -119,6 +119,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.hostname = "win10"
 
     cfg.vm.communicator = "winrm"
+    cfg.vm.provision "shell", inline: "Set-MpPreference -ExclusionPath C:\\commander.exe, C:\\Tools"
     cfg.vm.network :private_network, ip: "192.168.38.4", gateway: "192.168.38.1", dns: "192.168.38.2"
 
     cfg.vm.provision "shell", path: "scripts/fix-second-network.ps1", privileged: false, args: "-ip 192.168.38.4 -dns 192.168.38.2"

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -119,7 +119,6 @@ Vagrant.configure("2") do |config|
     cfg.vm.hostname = "win10"
 
     cfg.vm.communicator = "winrm"
-    cfg.vm.provision "shell", inline: "Set-MpPreference -ExclusionPath C:\\commander.exe, C:\\Tools"
     cfg.vm.network :private_network, ip: "192.168.38.4", gateway: "192.168.38.1", dns: "192.168.38.2"
 
     cfg.vm.provision "shell", path: "scripts/fix-second-network.ps1", privileged: false, args: "-ip 192.168.38.4 -dns 192.168.38.2"

--- a/Vagrant/scripts/install-utilities.ps1
+++ b/Vagrant/scripts/install-utilities.ps1
@@ -20,8 +20,9 @@ apm install language-batch
 apm install language-docker
 
 # Disable Windows Defender realtime scanning before downloading Mimikatz
-If ($hostname -eq "win10") {
+If ($env:computername -eq "WIN10") {
   set-MpPreference -DisableRealtimeMonitoring $true
+  Set-MpPreference -ExclusionPath C:\commander.exe, C:\Tools
 }
 
 # Purpose: Downloads and unzips a copy of the latest Mimikatz trunk


### PR DESCRIPTION
Lately Microsoft might have added signatures for the Mimikatz version that DetectionLab uses and for the commander.exe RAT that CALDERA deploys in order to work. This ends up in having the files in quarantine on the win10 machine and not being able to run the CALDERA framework.

This PR adds one inline shell script to the win10 provisioning process to add exceptions in the Windows Defender preferences for the C:\commander.exe binary and the whole C:\Tools folder.