### PR TITLE
Adding build timeout and hosting boxes on Dropbox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,17 +44,23 @@ jobs:
           shell: /bin/bash
           command: |
             export IP_ADDRESS=$(cat /tmp/ip_address)
-            while true
+            MINUTES_PAST=0
+            while [ "$MINUTES_PAST" -lt 120 ]
             do
             export STATUS=$(curl $IP_ADDRESS)
             if [ "$STATUS" == "building" ]; then
             echo "$STATUS"
             sleep 300
+            ((MINUTES_PAST+=5))
             else
             echo "$STATUS" > /tmp/status
             break
             fi
             done
+            if [ "$MINUTES_PAST" -gt 120 ]; then
+            curl -X DELETE --header 'Accept: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" 'https://api.packet.net/devices/'"$DEVICE_ID"
+            exit 1
+            fi
       - run:
           name: Recording build results
           shell: /bin/bash

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ There are two build scripts:
 
 Provider | Box  | URL | MD5 | Size
 ------------|-----|-----|----|----
-Virtualbox |Windows 2016 | https://s3-us-west-1.amazonaws.com/detectionlab/windows_2016_virtualbox.box | 614f984c82b51471b5bb753940b59d38 | 6.4GB
-Virtualbox | Windows 10 | https://s3-us-west-1.amazonaws.com/detectionlab/windows_10_virtualbox.box | 30b06e30b36b02ccf1dc5c04017654aa | 5.8GB
-VMware | Windows 2016 | https://s3-us-west-1.amazonaws.com/detectionlab/windows_2016_vmware.box | 1511b9dc942c69c2cc5a8dc471fa8865 | 6.7GB
-VMware | Windows 10 | https://s3-us-west-1.amazonaws.com/detectionlab/windows_10_vmware.box | 174ad0f0fd2089ff74a880c6dadac74c | 6.0GB
+Virtualbox |Windows 2016 | https://www.dropbox.com/s/u2hbtv0ynf1pei8/windows_2016_virtualbox.box?dl=1 | 614f984c82b51471b5bb753940b59d38 | 6.4GB
+Virtualbox | Windows 10 | https://www.dropbox.com/s/zt30zod4e0etug7/windows_10_virtualbox.box?dl=1 | 30b06e30b36b02ccf1dc5c04017654aa | 5.8GB
+VMware | Windows 2016 | https://www.dropbox.com/s/tvtl2r71amngnjs/windows_2016_vmware.box?dl=1 | 1511b9dc942c69c2cc5a8dc471fa8865 | 6.7GB
+VMware | Windows 10 | https://www.dropbox.com/s/9zqxn6lrryzow4v/windows_10_vmware.box?dl=1 | 174ad0f0fd2089ff74a880c6dadac74c | 6.0GB
 
 If you choose to download the boxes, you may skip steps 2 and 3. If you don't trust pre-built boxes, I recommend following steps 2 and 3 to build them on your machine.
 

--- a/build_vagrant_only.sh
+++ b/build_vagrant_only.sh
@@ -145,11 +145,11 @@ download_boxes() {
   PROVIDER="$2"
 
   if [ "$PROVIDER" == "virtualbox" ]; then
-    wget "https://s3-us-west-1.amazonaws.com/detectionlab/windows_2016_virtualbox.box" -O "$DL_DIR"/Boxes/windows_2016_virtualbox.box
-    wget "https://s3-us-west-1.amazonaws.com/detectionlab/windows_10_virtualbox.box" -O "$DL_DIR"/Boxes/windows_10_virtualbox.box
+    wget "https://www.dropbox.com/s/u2hbtv0ynf1pei8/windows_2016_virtualbox.box?dl=1" -O "$DL_DIR"/Boxes/windows_2016_virtualbox.box
+    wget "https://www.dropbox.com/s/zt30zod4e0etug7/windows_10_virtualbox.box?dl=1" -O "$DL_DIR"/Boxes/windows_10_virtualbox.box
   elif [ "$PROVIDER" == "vmware_fusion" ]; then
-    wget "https://s3-us-west-1.amazonaws.com/detectionlab/windows_2016_vmware.box" -O "$DL_DIR"/Boxes/windows_2016_vmware.box
-    wget "https://s3-us-west-1.amazonaws.com/detectionlab/windows_10_vmware.box" -O "$DL_DIR"/Boxes/windows_10_vmware.box
+    wget "https://www.dropbox.com/s/tvtl2r71amngnjs/windows_2016_vmware.box?dl=1" -O "$DL_DIR"/Boxes/windows_2016_vmware.box
+    wget "https://www.dropbox.com/s/9zqxn6lrryzow4v/windows_10_vmware.box?dl=1" -O "$DL_DIR"/Boxes/windows_10_vmware.box
   fi
 
   # Hacky workaround


### PR DESCRIPTION
- S3 hosting is expensive. Moving to dropbox.
- Giving the build process a 2 hour maximum time limit before destroying the Packet server