### PR TITLE
Fix virtualbox presence check in build_vagrant_only.sh

### DIFF
--- a/build_vagrant_only.sh
+++ b/build_vagrant_only.sh
@@ -29,10 +29,10 @@ check_vagrant() {
 
 # Returns 0 if not installed or 1 if installed
 check_virtualbox_installed() {
-  if ! which VBoxManage >/dev/null; then
-    echo "0"
-  else
+  if which VBoxManage >/dev/null; then
     echo "1"
+  else
+    echo "0"
   fi
 }
 

--- a/build_vagrant_only.sh
+++ b/build_vagrant_only.sh
@@ -30,9 +30,9 @@ check_vagrant() {
 # Returns 0 if not installed or 1 if installed
 check_virtualbox_installed() {
   if ! which VBoxManage >/dev/null; then
-    echo "1"
-  else
     echo "0"
+  else
+    echo "1"
   fi
 }
 


### PR DESCRIPTION
In build_vagrant.sh, the presence of virtualbox is checked by the check_virtualbox_installed() routine.  The return values are swapped though, so that a successful check will return 0 and block the installation process. For coherence with the build.sh script I just removed the `!` operator from the check instead of swapping the return values.