### PR TITLE
Revert "Updated Splunk UF and changed sysmon config"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ OS | Vagrant | Packer | Provider
 ---|---------|--------|-----------
 OSX 10.12.4 | 1.9.3 | 1.0.0 | Virtualbox (5.1.14)
 OSX 10.12.6 | 2.0.1 | 1.1.2 | Virtualbox (5.1.30)
-OSX 10.13.4 | 2.0.1 | 1.2.3 | Virtualbox (5.2.6)
 OSX 10.12.4 | 1.9.2 | 1.0.0 | VMWare Fusion (8.5.6)
 OSX 10.12.5 | 1.9.3 | 1.0.0 | VMWare Fusion (8.5.8)
 OSX 10.12.6 | 2.0.1 | 1.1.3 | VMWare Fusion (8.5.9)
@@ -241,7 +240,7 @@ Requests for tools and features will be reviewed on a case by case basis, but I 
 ## Credits/Resources
 A sizable percentage of this code was borrowed and adapted from [Stefan Scherer](https://twitter.com/stefscherer)'s [packer-windows](https://github.com/StefanScherer/packer-windows) and [adfs2](https://github.com/StefanScherer/adfs2) Github repos. A huge thanks to him for building the foundation that allowed me to design this lab environment.
 
-# Acknowledgements
+# Acknowledgements 
 * [Microsoft Advanced Threat Analytics](https://www.microsoft.com/en-us/cloud-platform/advanced-threat-analytics)
 * [Splunk](https://www.splunk.com)
 * [osquery](https://osquery.io)

--- a/Vagrant/scripts/install-splunkuf.ps1
+++ b/Vagrant/scripts/install-splunkuf.ps1
@@ -2,10 +2,10 @@
 
 If (-not (Test-Path "C:\Program Files\SplunkUniversalForwarder\bin\splunk.exe")) {
   Write-Host "Downloading Splunk"
-  $msiFile = $env:Temp + "\splunkforwarder-7.1.0-2e75b3406c5b-x64-release.msi"
+  $msiFile = $env:Temp + "\splunkforwarder-6.5.2-67571ef4b87d-x64-release.msi"
 
   Write-Host "Installing & Starting Splunk"
-  (New-Object System.Net.WebClient).DownloadFile('https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=windows&version=7.1.0&product=universalforwarder&filename=splunkforwarder-7.1.0-2e75b3406c5b-x64-release.msi&wget=true', $msiFile)
+  (New-Object System.Net.WebClient).DownloadFile('https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=windows&version=6.5.2&product=universalforwarder&filename=splunkforwarder-6.5.2-67571ef4b87d-x64-release.msi&wget=true', $msiFile)
   Start-Process -FilePath "c:\windows\system32\msiexec.exe" -ArgumentList '/i', "$msiFile", 'RECEIVING_INDEXER="192.168.38.5:9997" WINEVENTLOG_SEC_ENABLE=1 WINEVENTLOG_SYS_ENABLE=1 WINEVENTLOG_APP_ENABLE=1 AGREETOLICENSE=Yes SERVICESTARTTYPE=1 LAUNCHSPLUNK=1 /quiet' -Wait
 } Else {
   Write-Host "Splunk is already installed. Moving on."

--- a/Vagrant/scripts/install-sysinternals.ps1
+++ b/Vagrant/scripts/install-sysinternals.ps1
@@ -32,8 +32,14 @@ Invoke-WebRequest -Uri "https://live.sysinternals.com/Sysmon64.exe" -Outfile $sy
 Invoke-WebRequest -Uri "https://live.sysinternals.com/Tcpview.exe" -Outfile $tcpviewPath
 Copy-Item $sysmonPath $sysmonDir
 
-# Download Olaf Hartong's Sysmon config
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/olafhartong/sysmon-modular/master/sysmonconfig.xml" -Outfile "$sysmonConfigPath"
+# Download SwiftOnSecurity's Sysmon config
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml" -Outfile "$sysmonConfigPath"
+
+# Convert Sysmon config schema from 3.30 to 4.0 per GitHub Issue #38
+(Get-Content $sysmonConfigPath) -replace 'schemaversion="3.30"', 'schemaversion="4.00"' | Set-Content $sysmonConfigPath
+
+# Convert Schema from 3.30 to 4.0 per GitHub Issue #38
+(Get-Content $sysmonConfigPath) -replace 'schemaversion="3.30"', 'schemaversion="4.00"' | Set-Content $sysmonConfigPath
 
 # Startup Sysmon
 Write-Host "Starting Sysmon..."


### PR DESCRIPTION
Reverts clong/DetectionLab#92

This commit actually fails because the new version of Splunk requires the admin password to be suppled when Splunk is installed: http://docs.splunk.com/Documentation/Forwarder/7.1.0/Forwarder/InstallaWindowsuniversalforwarderfromthecommandline#Have_a_password_for_the_Splunk_admin_user_ready

> If you do not supply a password during a silent installation, the universal forwarder can install without any users defined, which prevents login.

During the Windows_TA installation, the error message is:
`No users exist. Please set up a user.`

I think the CI pipeline is not seeing PRs made on forks correctly, so I need to address that as well.
