### PR TITLE
Change 7-zip url to https

### DIFF
--- a/Packer/scripts/vm-guest-tools.bat
+++ b/Packer/scripts/vm-guest-tools.bat
@@ -1,5 +1,5 @@
 if not exist "C:\Windows\Temp\7z920-x64.msi" (
-    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://www.7-zip.org/a/7z920-x64.msi', 'C:\Windows\Temp\7z920-x64.msi')" <NUL
+    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z920-x64.msi', 'C:\Windows\Temp\7z920-x64.msi')" <NUL
 )
 msiexec /qb /i C:\Windows\Temp\7z920-x64.msi
 


### PR DESCRIPTION
7-zip is no longer available on http, and redirects to Sourceforge. By using https directly in the script, it will work like before.