### PR TITLE
Multiple bug fixes

### DIFF
--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -74,6 +74,7 @@ Vagrant.configure("2") do |config|
       v.memory = 2560
       v.cpus = 2
       v.gui = true
+      v.enable_vmrun_ip_lookup = false
     end
 
     cfg.vm.provider "virtualbox" do |vb, override|
@@ -105,10 +106,10 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", path: "scripts/install-wefsubscriptions.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-splunkuf.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-windows_ta.ps1", privileged: true
+    cfg.vm.provision "shell", path: "scripts/install-inputsconf.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-utilities.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-osquery.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-caldera-agent.ps1", privileged: true
-    cfg.vm.provision "shell", path: "scripts/install-inputsconf.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-sysinternals.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/configure-pslogstranscriptsshare.ps1", privileged: true
     cfg.vm.provision "shell", path: "scripts/install-autorunstowineventlog.ps1", privileged: true
@@ -127,6 +128,7 @@ Vagrant.configure("2") do |config|
       v.memory = 2048
       v.cpus = 2
       v.gui = true
+      v.enable_vmrun_ip_lookup = false
     end
 
     cfg.vm.provider "virtualbox" do |vb, override|
@@ -180,6 +182,7 @@ Vagrant.configure("2") do |config|
       v.memory = 2048
       v.cpus = 1
       v.gui = true
+      v.enable_vmrun_ip_lookup = false
     end
 
     cfg.vm.provider "virtualbox" do |vb, override|

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -13,7 +13,11 @@ apt_install_prerequisites() {
 }
 
 fix_eth1_static_ip() {
-  # Fix static IP if it's not set correctly
+  # There's a fun issue where dhclient keeps messing with eth1 despite the fact
+  # that eth1 has a static IP set. We workaround this by telling dhclient to leave it alone.
+  echo 'interface "eth1" {}' >> /etc/dhcp/dhclient.conf
+  systemctl restart networking.service
+  # Fix eth1 if the IP isn't set correctly
   ETH1_IP=$(ifconfig eth1 | grep 'inet addr' | cut -d ':' -f 2 | cut -d ' ' -f 1)
   if [ "$ETH1_IP" != "192.168.38.5" ]; then
     echo "Incorrect IP Address settings detected. Attempting to fix."
@@ -54,10 +58,10 @@ install_golang() {
     mkdir /home/vagrant/.go
     chown vagrant:vagrant /home/vagrant/.go
     mkdir /root/.go
-    echo 'export GOPATH=$HOME/.go' >> /home/vagrant/.bashrc
+    echo 'export GOPATH=$HOME/.go' >> /home/vagrant/.
     echo 'export GOROOT=/usr/local/go' >> /home/vagrant/.bashrc
     echo 'export GOPATH=$HOME/.go' >> /root/.bashrc
-    echo '/home/vagrant/.bashrc' >> /root/.bashrc
+    echo 'export GOROOT=/usr/local/go' >> /root/.bashrc
     source /root/.bashrc
     sudo update-alternatives --install "/usr/bin/go" "go" "/usr/local/go/bin/go" 0
     sudo update-alternatives --set go /usr/local/go/bin/go
@@ -66,7 +70,6 @@ install_golang() {
     echo "GoLang seems to be downloaded already.. Skipping."
   fi
 }
-
 
 install_splunk() {
   # Check if Splunk is already installed

--- a/Vagrant/scripts/configure-wef-gpo.ps1
+++ b/Vagrant/scripts/configure-wef-gpo.ps1
@@ -9,9 +9,7 @@ $GPO = Get-GPO -Name $GPOName
 If ($gPLinks.LinkedGroupPolicyObjects -notcontains $gpo.path)
 {
     New-GPLink -Name $GPOName -Target $OU -Enforced yes
-}
-else
-{
+} else {
     Write-Host "GpLink $GPOName already linked on $OU. Moving On."
 }
 $OU = "ou=Domain Controllers,dc=windomain,dc=local"
@@ -21,9 +19,17 @@ $GPO = Get-GPO -Name $GPOName
 If ($gPLinks.LinkedGroupPolicyObjects -notcontains $gpo.path)
 {
     New-GPLink -Name $GPOName -Target $OU -Enforced yes
+} else {
+    Write-Host "GpLink $GPOName already linked on $OU. Moving On."
 }
-else
+$OU = "ou=Workstations,dc=windomain,dc=local"
+$gpLinks = $null
+$gPLinks = Get-ADOrganizationalUnit -Identity $OU -Properties name,distinguishedName, gPLink, gPOptions
+$GPO = Get-GPO -Name $GPOName
+If ($gPLinks.LinkedGroupPolicyObjects -notcontains $gpo.path)
 {
+    New-GPLink -Name $GPOName -Target $OU -Enforced yes
+} else {
     Write-Host "GpLink $GPOName already linked on $OU. Moving On."
 }
 

--- a/Vagrant/scripts/install-inputsconf.ps1
+++ b/Vagrant/scripts/install-inputsconf.ps1
@@ -20,9 +20,9 @@ if ($currentContent -ne $targetContent)
     Write-Host "Starting the Splunk forwarder"
     Start-Service splunkforwarder
 }
-else 
+else
 {
-    Write-Host "Splunk forwarder already configured. Moving on." 
+    Write-Host "Splunk forwarder already configured. Moving on."
 }
 If ((Get-Service -name splunkforwarder).Status -ne "Running")
 {

--- a/ci/circle_workflows/packer_and_vagrant_changes.sh
+++ b/ci/circle_workflows/packer_and_vagrant_changes.sh
@@ -7,13 +7,6 @@ if [ ! -d "/tmp/artifacts" ]; then
   mkdir /tmp/artifacts
 fi
 
-## Delete stale servers if they exist
-DELETE_DEVICE_ID=$(curl -X GET -s --header 'Accept: application/json' --header 'X-Auth-Token:  '"$PACKET_API_TOKEN" 'https://api.packet.net/projects/0b3f4f2e-ff05-41a8-899d-7923f620ca85/devices' | jq ."devices[0].id" | tr -d '"')
-if [ "$(echo -n $DELETE_DEVICE_ID | wc -c)" -eq 36 ]; then
-  echo "Requesting deletion for Packet server with ID $DELETE_DEVICE_ID"
-  curl -X DELETE -s --header 'Accept: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" 'https://api.packet.net/devices/'"$DELETE_DEVICE_ID"
-fi
-
 ## Provision a Type1 baremetal Packet.net server
 echo "Provisioning a server on Packet.net"
 DEVICE_ID=$(curl -s -X POST --header 'Accept: application/json' --header 'Content-Type: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" -d '{ "facility": "sjc1", "plan": "baremetal_1", "hostname": "detectionlab", "description": "testing", "billing_cycle": "hourly", "operating_system": "ubuntu_16_04", "userdata": "", "locked": "false", "project_ssh_keys": ["315a9565-d5b1-41b6-913d-fcf022bb89a6", "755b134a-f63c-4fc5-9103-c1b63e65fdfc"] }' 'https://api.packet.net/projects/0b3f4f2e-ff05-41a8-899d-7923f620ca85/devices' | jq ."id" | tr -d '"')

--- a/ci/circle_workflows/packer_changes.sh
+++ b/ci/circle_workflows/packer_changes.sh
@@ -7,14 +7,6 @@ if [ ! -d "/tmp/artifacts" ]; then
   mkdir /tmp/artifacts
 fi
 
-## Delete stale servers if they exist
-echo "Deleting stale Packet.net servers"
-DELETE_DEVICE_ID=$(curl -X GET -s --header 'Accept: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" 'https://api.packet.net/projects/0b3f4f2e-ff05-41a8-899d-7923f620ca85/devices' | jq ."devices[0].id" | tr -d '"')
-if [ "$(echo -n $DELETE_DEVICE_ID | wc -c)" -eq 36 ]; then
-  echo "Requesting deletion for Packet server with ID $DELETE_DEVICE_ID"
-  curl -X DELETE -s --header 'Accept: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" 'https://api.packet.net/devices/'"$DELETE_DEVICE_ID"
-fi
-
 ## Provision two Type1 baremetal Packet.net servers
 echo "Provisioning packerwindows2016 on Packet.net"
 SERVER1_ID=$(curl -X POST -s --header 'Accept: application/json' --header 'Content-Type: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" -d '{ "facility": "sjc1", "plan": "baremetal_1", "hostname": "packerwindows2016", "description": "testing", "billing_cycle": "hourly", "operating_system": "ubuntu_16_04", "userdata": "", "locked": "false", "project_ssh_keys":["315a9565-d5b1-41b6-913d-fcf022bb89a6", "755b134a-f63c-4fc5-9103-c1b63e65fdfc"] }' 'https://api.packet.net/projects/0b3f4f2e-ff05-41a8-899d-7923f620ca85/devices' | jq ."id" | tr -d '"')

--- a/ci/circle_workflows/vagrant_changes.sh
+++ b/ci/circle_workflows/vagrant_changes.sh
@@ -7,13 +7,6 @@ if [ ! -d "/tmp/artifacts" ]; then
   mkdir /tmp/artifacts
 fi
 
-## Delete stale servers if they exist
-DELETE_DEVICE_ID=$(curl -X GET -s --header 'Accept: application/json' --header 'X-Auth-Token:  '"$PACKET_API_TOKEN" 'https://api.packet.net/projects/0b3f4f2e-ff05-41a8-899d-7923f620ca85/devices' | jq ."devices[0].id" | tr -d '"')
-if [ "$(echo -n $DELETE_DEVICE_ID | wc -c)" -eq 36 ]; then
-  echo "Requesting deletion for Packet server with ID $DELETE_DEVICE_ID"
-  curl -X -s DELETE --header 'Accept: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" 'https://api.packet.net/devices/'"$DELETE_DEVICE_ID"
-fi
-
 ## Provision a Type1 baremetal Packet.net server
 echo "Provisioning a server on Packet.net"
 DEVICE_ID=$(curl -s -X POST --header 'Accept: application/json' --header 'Content-Type: application/json' --header 'X-Auth-Token: '"$PACKET_API_TOKEN" -d '{ "facility": "sjc1", "plan": "baremetal_1", "hostname": "detectionlab", "description": "testing", "billing_cycle": "hourly", "operating_system": "ubuntu_16_04", "userdata": "", "locked": "false", "project_ssh_keys": ["315a9565-d5b1-41b6-913d-fcf022bb89a6", "755b134a-f63c-4fc5-9103-c1b63e65fdfc"] }' 'https://api.packet.net/projects/0b3f4f2e-ff05-41a8-899d-7923f620ca85/devices' | jq ."id" | tr -d '"')


### PR DESCRIPTION
* Setting `v.enable_vmrun_ip_lookup = false` seems to fix the issue described in #114 
* The Windows Event Forwarding Server was not being applied to the Workstations OU
* Logger keeps reverting to DHCP on eth1 which messes up all the things. This should disable dhclient on that interface.
* Fixed a typo in the .bashrc on logger
* Don't delete Packet servers when doing CI tests (causes messy race conditions)