### PR TITLE
Rename virtualbox VM names to predictable [ci skip]

### DIFF
--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -20,6 +20,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "virtualbox" do |vb, override|
       vb.gui = true
+      vb.name = "logger.windomain.local"
       vb.customize ["modifyvm", :id, "--memory", 4096]
       vb.customize ["modifyvm", :id, "--cpus", 2]
       vb.customize ["modifyvm", :id, "--vram", "32"]
@@ -80,6 +81,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "virtualbox" do |vb, override|
       vb.gui = true
+      vb.name = "dc.windomain.local"
       vb.customize ["modifyvm", :id, "--memory", 2560]
       vb.customize ["modifyvm", :id, "--cpus", 2]
       vb.customize ["modifyvm", :id, "--vram", "32"]
@@ -134,6 +136,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "virtualbox" do |vb, override|
       vb.gui = true
+      vb.name = "wef.windomain.local"
       vb.customize ["modifyvm", :id, "--memory", 2048]
       vb.customize ["modifyvm", :id, "--cpus", 2]
       vb.customize ["modifyvm", :id, "--vram", "32"]
@@ -188,6 +191,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "virtualbox" do |vb, override|
       vb.gui = true
+      vb.name = "win10.windomain.local"
       vb.customize ["modifyvm", :id, "--memory", 2048]
       vb.customize ["modifyvm", :id, "--cpus", 1]
       vb.customize ["modifyvm", :id, "--vram", "32"]

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -7,12 +7,14 @@ Vagrant.configure("2") do |config|
     cfg.vm.network :private_network, ip: "192.168.38.5", gateway: "192.168.38.1", dns: "8.8.8.8"
 
     cfg.vm.provider "vmware_fusion" do |v, override|
+      v.vmx["displayname"] = "logger"
       v.memory = 2048
       v.cpus = 1
       v.gui = true
     end
 
     cfg.vm.provider "vmware_desktop" do |v, override|
+      v.vmx["displayname"] = "logger"
       v.memory = 4096
       v.cpus = 2
       v.gui = true
@@ -20,7 +22,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "virtualbox" do |vb, override|
       vb.gui = true
-      vb.name = "logger.windomain.local"
+      vb.name = "logger"
       vb.customize ["modifyvm", :id, "--memory", 4096]
       vb.customize ["modifyvm", :id, "--cpus", 2]
       vb.customize ["modifyvm", :id, "--vram", "32"]
@@ -66,6 +68,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "vmware_fusion" do |v, override|
       override.vm.box = "../Boxes/windows_2016_vmware.box"
+      v.vmx["displayname"] = "dc.windomain.local"
       v.memory = 2560
       v.cpus = 2
       v.gui = true
@@ -73,6 +76,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "vmware_desktop" do |v, override|
       override.vm.box = "../Boxes/windows_2016_vmware.box"
+      v.vmx["displayname"] = "dc.windomain.local"
       v.memory = 2560
       v.cpus = 2
       v.gui = true
@@ -121,6 +125,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "vmware_fusion" do |v, override|
       override.vm.box = "../Boxes/windows_2016_vmware.box"
+      v.vmx["displayname"] = "wef.windomain.local"
       v.memory = 2048
       v.cpus = 2
       v.gui = true
@@ -128,6 +133,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "vmware_desktop" do |v, override|
       override.vm.box = "../Boxes/windows_2016_vmware.box"
+      v.vmx["displayname"] = "wef.windomain.local"
       v.memory = 2048
       v.cpus = 2
       v.gui = true
@@ -171,6 +177,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "vmware_fusion" do |v, override|
       override.vm.box = "../Boxes/windows_10_vmware.box"
+      v.vmx["displayname"] = "win10.windomain.local"
       v.vmx["gui.fullscreenatpoweron"] = "FALSE"
       v.vmx["gui.viewModeAtPowerOn"] = "windowed"
       v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
@@ -181,6 +188,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider "vmware_desktop" do |v, override|
       override.vm.box = "../Boxes/windows_10_vmware.box"
+      v.vmx["displayname"] = "win10.windomain.local"
       v.vmx["gui.fullscreenatpoweron"] = "FALSE"
       v.vmx["gui.viewModeAtPowerOn"] = "windowed"
       v.memory = 2048


### PR DESCRIPTION
Hi!
I suggest you to add this to make virtualbox vm names more predictable.
Now i suspect that virtualbox vm names are slightly random.

cfg.vm.provider "virtualbox" do |vb, override|
...
vb.name = "name.windomain.local"
...
end