### PR TITLE
Make correction to dc dns settings

### DIFF
--- a/Vagrant/scripts/create-domain.ps1
+++ b/Vagrant/scripts/create-domain.ps1
@@ -43,12 +43,13 @@ if ((gwmi win32_computersystem).partofdomain -eq $false) {
     -SysvolPath "C:\Windows\SYSVOL" `
     -Force:$true
 
-  $newDNSServers = "8.8.8.8", "4.4.4.4"
-  $adapters = Get-WmiObject Win32_NetworkAdapterConfiguration | Where-Object { $_.IPAddress -And ($_.IPAddress).StartsWith($subnet) }
-  if ($adapters) {
-    Write-Host Setting DNS
-    $adapters | ForEach-Object {$_.SetDNSServerSearchOrder($newDNSServers)}
-  }
+  #$newDNSServers = "8.8.8.8", "4.4.4.4"
+  #$adapters = Get-WmiObject Win32_NetworkAdapterConfiguration | Where-Object { $_.IPAddress -And ($_.IPAddress).StartsWith($subnet) }
+  #if ($adapters) {
+  #  Write-Host Setting DNS
+  #  $adapters | ForEach-Object {$_.SetDNSServerSearchOrder($newDNSServers)}
+  #}
+  
   Write-Host "Setting timezone to UTC"
   c:\windows\system32\tzutil.exe /s "UTC"
   Write-Host "Excluding NAT interface from DNS"


### PR DESCRIPTION
Hi!
Why we set DC dns server settings to Google public dns?
I think this is wrong.
I suggest you to remove this code block.  

Our DC DNS Server can resolve all registered public dns records by himself alone with root hints file.
DNS Server automatically configured in Active Directory preparation domain wizard. 
Network adapters on dc is automatycally configured to resolve named thru 127.0.0.1

Only thing that make now configuration to work is DNS ipv6 localhost listening address.
If you sometime do disable ipv6, DNS resolving will break.

I cannot understand, why so many people do this mistake everyday.

Here is example of explanation what could go wrong
https://redmondmag.com/articles/2004/05/01/10-dns-errors-that-will-kill-your-network.aspx
The first mistake and problems is explained there.


Now i see incorrect dns settings on dc

PS C:\Windows\system32> ipconfig /all
Ethernet adapter Ethernet:
   Connection-specific DNS Suffix  . :
   Description . . . . . . . . . . . : Intel(R) PRO/1000 MT Desktop Adapter
   Physical Address. . . . . . . . . : 08-00-27-F7-0B-F3
   DHCP Enabled. . . . . . . . . . . : Yes
   Autoconfiguration Enabled . . . . : Yes
   Link-local IPv6 Address . . . . . : fe80::e4d6:dbc:bb0e:7b18%6(Preferred)
   IPv4 Address. . . . . . . . . . . : 10.0.2.15(Preferred)
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Lease Obtained. . . . . . . . . . : Tuesday, September 4, 2018 7:14:53 AM
   Lease Expires . . . . . . . . . . : Wednesday, September 5, 2018 7:14:54 AM
   Default Gateway . . . . . . . . . : 10.0.2.2
   DHCP Server . . . . . . . . . . . : 10.0.2.2
   DHCPv6 IAID . . . . . . . . . . . : 50855975
   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-23-20-47-ED-08-00-27-F7-0B-F3
   DNS Servers . . . . . . . . . . . : ::1
                                       8.8.8.8
                                       4.4.4.4
   NetBIOS over Tcpip. . . . . . . . : Enabled

Ethernet adapter Ethernet 2:

   Connection-specific DNS Suffix  . :
   Description . . . . . . . . . . . : Intel(R) PRO/1000 MT Desktop Adapter #2
   Physical Address. . . . . . . . . : 08-00-27-54-96-56
   DHCP Enabled. . . . . . . . . . . : No
   Autoconfiguration Enabled . . . . : Yes
   Link-local IPv6 Address . . . . . : fe80::7821:bcd3:84cf:24a4%5(Preferred)
   IPv4 Address. . . . . . . . . . . : 172.25.0.100(Preferred)
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . :
   DHCPv6 IAID . . . . . . . . . . . : 67633191
   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-23-20-47-ED-08-00-27-F7-0B-F3
   DNS Servers . . . . . . . . . . . : ::1
                                       8.8.8.8
                                       4.4.4.4
   NetBIOS over Tcpip. . . . . . . . : Enabled