### PR TITLE
Set timezone with vagrant-timezone plugin

### DIFF
--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -1,5 +1,14 @@
 Vagrant.configure("2") do |config|
+  
+  required_plugins = %w(vagrant-timezone)
+  required_plugins.each do |plugin|
+    exec "vagrant plugin install #{plugin};vagrant #{ARGV.join(" ")}" unless Vagrant.has_plugin? plugin || ARGV[0] == 'plugin'
+  end
 
+  if Vagrant.has_plugin?("vagrant-timezone")
+    config.timezone.value = :host
+  end
+  
   config.vm.define "logger" do |cfg|
     cfg.vm.box = "bento/ubuntu-16.04"
     cfg.vm.hostname = "logger"


### PR DESCRIPTION
Hi!
I suggest you to use vagrant-timezone plugin https://github.com/tmatilai/vagrant-timezone
1. Add suggested changes to Vagrantfile
2. remove any timezones related configs, that was hardcoded in scripts.
3. vagrant-plugin will be downloaded and installed automatically from internet, if it not installed yet everytime you start vagrant up
 
just add in Vagrantfile  this code block
...
  required_plugins = %w( vagrant-vbguest vagrant-timezone)
  required_plugins.each do |plugin|
      exec "vagrant plugin install #{plugin};vagrant #{ARGV.join(" ")}" unless Vagrant.has_plugin? plugin || ARGV[0] == 'plugin'
  end
  if Vagrant.has_plugin?("vagrant-timezone")
    config.timezone.value = :host
  end
...
And everytime you will vagrant up, timezone config will be picked up from host and set in VM.