### PR TITLE
Deprecate VMware Fusion Provider & Update Splunk v7.2.5.1

### DIFF
--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -6,13 +6,6 @@ Vagrant.configure("2") do |config|
     config.vm.provision :shell, path: "bootstrap.sh"
     cfg.vm.network :private_network, ip: "192.168.38.105", gateway: "192.168.38.1", dns: "8.8.8.8"
 
-    cfg.vm.provider "vmware_fusion" do |v, override|
-      v.vmx["displayname"] = "logger"
-      v.memory = 2048
-      v.cpus = 1
-      v.gui = true
-    end
-
     cfg.vm.provider "vmware_desktop" do |v, override|
       v.vmx["displayname"] = "logger"
       v.memory = 4096
@@ -69,14 +62,6 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", inline: 'wevtutil el | Select-String -notmatch "Microsoft-Windows-LiveId" | Foreach-Object {wevtutil cl "$_"}', privileged: false
     cfg.vm.provision "shell", inline: "Set-SmbServerConfiguration -AuditSmb1Access $true -Force", privileged: false
 
-    cfg.vm.provider "vmware_fusion" do |v, override|
-      override.vm.box = "../Boxes/windows_2016_vmware.box"
-      v.vmx["displayname"] = "dc.windomain.local"
-      v.memory = 2560
-      v.cpus = 2
-      v.gui = true
-    end
-
     cfg.vm.provider "vmware_desktop" do |v, override|
       override.vm.box = "../Boxes/windows_2016_vmware.box"
       v.vmx["displayname"] = "dc.windomain.local"
@@ -130,14 +115,6 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", inline: "Set-SmbServerConfiguration -AuditSmb1Access $true -Force", privileged: false
     cfg.vm.provision "shell", path: "scripts/install-microsoft-ata.ps1", privileged: false
 
-    cfg.vm.provider "vmware_fusion" do |v, override|
-      override.vm.box = "../Boxes/windows_2016_vmware.box"
-      v.vmx["displayname"] = "wef.windomain.local"
-      v.memory = 2048
-      v.cpus = 2
-      v.gui = true
-    end
-
     cfg.vm.provider "vmware_desktop" do |v, override|
       override.vm.box = "../Boxes/windows_2016_vmware.box"
       v.vmx["displayname"] = "wef.windomain.local"
@@ -186,17 +163,6 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell", path: "scripts/install-inputsconf.ps1", privileged: false
     cfg.vm.provision "shell", path: "scripts/install-sysinternals.ps1", privileged: false
     cfg.vm.provision "shell", path: "scripts/install-autorunstowineventlog.ps1", privileged: false
-
-    cfg.vm.provider "vmware_fusion" do |v, override|
-      override.vm.box = "../Boxes/windows_10_vmware.box"
-      v.vmx["displayname"] = "win10.windomain.local"
-      v.vmx["gui.fullscreenatpoweron"] = "FALSE"
-      v.vmx["gui.viewModeAtPowerOn"] = "windowed"
-      v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
-      v.memory = 2048
-      v.cpus = 1
-      v.gui = true
-    end
 
     cfg.vm.provider "vmware_desktop" do |v, override|
       override.vm.box = "../Boxes/windows_10_vmware.box"

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -72,8 +72,8 @@ install_splunk() {
     # Get Splunk.com into the DNS cache. Sometimes resolution randomly fails during wget below
     dig @8.8.8.8 splunk.com
     # Download Splunk
-    wget --progress=bar:force -O splunk-7.2.4.2-fb30470262e3-linux-2.6-amd64.deb 'https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=linux&version=7.2.4.2&product=splunk&filename=splunk-7.2.4.2-fb30470262e3-linux-2.6-amd64.deb&wget=true'
-    dpkg -i splunk-7.2.4.2-fb30470262e3-linux-2.6-amd64.deb
+    wget --progress=bar:force -O splunk-7.2.5.1-962d9a8e1586-linux-2.6-amd64.deb 'https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=linux&version=7.2.5.1&product=splunk&filename=splunk-7.2.5.1-962d9a8e1586-linux-2.6-amd64.deb&wget=true'
+    dpkg -i splunk-7.2.5.1-962d9a8e1586-linux-2.6-amd64.deb
     /opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt --seed-passwd changeme
     /opt/splunk/bin/splunk add index wineventlog -auth 'admin:changeme'
     /opt/splunk/bin/splunk add index osquery -auth 'admin:changeme'


### PR DESCRIPTION
VMware Fusion is no longer a supported standalone provider. VMWare Desktop is the only supported provider: https://www.vagrantup.com/vmware/index.html