### PR TITLE
Fixes #284

### DIFF
--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -2,7 +2,7 @@
 provider "aws" {
   shared_credentials_file = "${var.shared_credentials_file}"
   region = "${var.region}"
-  profile = "terraform"
+  profile = "${var.profile}"
 }
 
 # Create a VPC to launch our instances into

--- a/Terraform/terraform.tfvars.example
+++ b/Terraform/terraform.tfvars.example
@@ -1,4 +1,5 @@
 region = "us-west-1"
+profile = "terraform"
 shared_credentials_file = "/home/user/.aws/credentials"
 public_key_name = "id_logger"
 public_key_path = "/home/user/.ssh/id_logger.pub"

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -1,6 +1,9 @@
 variable "region" {
   default = "us-west-1"
 }
+variable "profile" {
+  default = "terraform"
+}
 variable "availability_zone" {
   description = "https://www.terraform.io/docs/providers/aws/d/availability_zone.html"
   default = ""


### PR DESCRIPTION
Changes the AWS profile to be a user-supplied variable, opposed to
statically being just `terraform`.