### PR TITLE
local AMI vars should override data sources

### DIFF
--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -142,7 +142,7 @@ resource "aws_key_pair" "auth" {
 
 resource "aws_instance" "logger" {
   instance_type = "t2.medium"
-  ami           = coalesce(data.aws_ami.logger_ami.image_id, var.logger_ami)
+  ami           = coalesce(var.logger_ami, data.aws_ami.logger_ami.image_id)
 
   tags = {
     Name = "logger"
@@ -190,7 +190,7 @@ resource "aws_instance" "dc" {
   instance_type = "t2.medium"
 
   # Uses the local variable if external data source resolution fails
-  ami = coalesce(data.aws_ami.dc_ami.image_id, var.dc_ami)
+  ami = coalesce(var.dc_ami, data.aws_ami.dc_ami.image_id)
 
   tags = {
     Name = "dc.windomain.local"
@@ -209,7 +209,7 @@ resource "aws_instance" "wef" {
   instance_type = "t2.medium"
 
   # Uses the local variable if external data source resolution fails
-  ami = coalesce(data.aws_ami.wef_ami.image_id, var.wef_ami)
+  ami = coalesce(var.wef_ami, data.aws_ami.wef_ami.image_id)
 
   tags = {
     Name = "wef.windomain.local"
@@ -228,7 +228,7 @@ resource "aws_instance" "win10" {
   instance_type = "t2.medium"
 
   # Uses the local variable if external data source resolution fails
-  ami = coalesce(data.aws_ami.win10_ami.image_id, var.win10_ami)
+  ami = coalesce(var.win10_ami, data.aws_ami.win10_ami.image_id)
 
   tags = {
     Name = "win10.windomain.local"


### PR DESCRIPTION
hi!

thank you for building detection lab!

when setting this up on AWS, i wanted to use my own AMIs built using your instructions. however, during the terraform step, terraform plan always returned the community AMIs rather than the ones i had just taken the time to build:
```
--
  # aws_instance.dc will be created
  + resource "aws_instance" "dc" {
      + ami                          = "ami-03e2df055c632a0dd" # not my AMI
--
  # aws_instance.logger will be created
  + resource "aws_instance" "logger" {
      + ami                          = "ami-0ad16744583f21877" # not my AMI
--
  # aws_instance.wef will be created
  + resource "aws_instance" "wef" {
      + ami                          = "ami-03c82482c03a740c5" # not my AMI
--
  # aws_instance.win10 will be created
  + resource "aws_instance" "win10" {
      + ami                          = "ami-0a4644e74768900f7" # not my AMI
```

i believe this is unintended behavior, but per the terraform [documentation](https://www.terraform.io/docs/configuration/functions/coalesce.html), `coalesce takes any number of arguments and returns the first one that isn't null or an empty string.` in this case it will always choose the data source over the user provided override. this patch should enable the functionality you intended with the local variable overrides