### PR TITLE
Force powershell to use TLS 1.2 as chocolatey.org throws a TLS error

### DIFF
--- a/Vagrant/scripts/install-utilities.ps1
+++ b/Vagrant/scripts/install-utilities.ps1
@@ -1,6 +1,7 @@
 # Purpose: Installs chocolatey package manager, then installs custom utilities from Choco.
 
 If (-not (Test-Path "C:\ProgramData\chocolatey")) {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   Write-Host "Installing Chocolatey"
   iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 } else {


### PR DESCRIPTION
<img width="1668" alt="Screenshot 2020-02-05 02 51 08" src="https://user-images.githubusercontent.com/1170490/73794674-63b11a80-47c2-11ea-8cf2-2f5dbdce920e.png">
