### PR TITLE
Set WinRM remoteip to any when packing the boxes.

### DIFF
--- a/Packer/scripts/enable-winrm.ps1
+++ b/Packer/scripts/enable-winrm.ps1
@@ -8,7 +8,7 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 winrm set winrm/config/client/auth '@{Basic="true"}'
 winrm set winrm/config/listener?Address=*+Transport=HTTP '@{Port="5985"}'
 netsh advfirewall firewall set rule group="Windows Remote Administration" new enable=yes
-netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=allow
+netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=allow remoteip=any
 sc config winrm start= disabled
 reg add HKCU\Software\Microsoft\Windows\CurrentVersion\RunOnce /v StartWinRM /t REG_SZ /f /d "cmd.exe /c 'sc config winrm start= auto & sc start winrm'"
 Restart-Service winrm


### PR DESCRIPTION
When using custom AMIs and for some reason both of WEF and win10 images `Windows Remote Management (HTTP-In)` FW rule `remoteip` gets set to `Local subnet`

![Screenshot 2020-02-12 23 03 39](https://user-images.githubusercontent.com/1170490/74369225-76dd6f00-4dee-11ea-8baf-9baefe5ea5b9.png)
