### PR TITLE
ssh_wait_time is deprecated

### DIFF
--- a/ESXi/Packer/ubuntu1804_esxi.json
+++ b/ESXi/Packer/ubuntu1804_esxi.json
@@ -45,7 +45,7 @@
             "ssh_password": "vagrant",
             "ssh_port": 22,
             "ssh_username": "vagrant",
-            "ssh_wait_timeout": "10000s",
+            "pause_before_connecting": "10m",
             "tools_upload_flavor": "linux",
             "type": "vmware-iso",
             "vm_name": "Ubuntu1804",


### PR DESCRIPTION
new option is pause_before connecting as previous is deprecated within packer https://packer.io/docs/templates/communicator.html#ssh_timeout

Also time is set to 166m by default so have flipped that to 10m to make it work :-)