### PR TITLE
Update to ubuntu1804_esxi.json with ssh_timeout

### DIFF
--- a/ESXi/Packer/ubuntu1804_esxi.json
+++ b/ESXi/Packer/ubuntu1804_esxi.json
@@ -45,6 +45,7 @@
             "ssh_password": "vagrant",
             "ssh_port": 22,
             "ssh_username": "vagrant",
+            "ssh_timeout": "10000s",
             "pause_before_connecting": "10m",
             "tools_upload_flavor": "linux",
             "type": "vmware-iso",


### PR DESCRIPTION
Added ssh_timeout of 10000 seconds (166.6667 minutes). This will keep packer from destroying the VM before it's even done with the setup process. The time can be adjusted but this helped me in the setup process.