### PR TITLE
Fix Win10 Activation Issue on Terraform

### DIFF
--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -241,8 +241,6 @@ resource "aws_instance" "wef" {
   provisioner "remote-exec" {
     inline = [
       "choco install -force -y winpcap",
-      "cscript c:\\windows\\system32\\slmgr.vbs -rearm",
-      "shutdown -r",
     ]
 
     connection {
@@ -273,7 +271,10 @@ resource "aws_instance" "win10" {
   instance_type = "t2.medium"
 
   provisioner "remote-exec" {
-    inline = ["choco install -force -y winpcap"]
+    inline = [
+      "choco install -force -y winpcap",
+      "cscript c:\\windows\\system32\\slmgr.vbs /ato",
+    ]
 
     connection {
       type     = "winrm"

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -8,7 +8,7 @@ variable "profile" {
 
 variable "availability_zone" {
   description = "https://www.terraform.io/docs/providers/aws/d/availability_zone.html"
-  default     = "us-west-1b"
+  default     = ""
 }
 
 variable "shared_credentials_file" {

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -8,7 +8,7 @@ variable "profile" {
 
 variable "availability_zone" {
   description = "https://www.terraform.io/docs/providers/aws/d/availability_zone.html"
-  default     = ""
+  default     = "us-west-1b"
 }
 
 variable "shared_credentials_file" {

--- a/ci/manual_machine_bootstrap.sh
+++ b/ci/manual_machine_bootstrap.sh
@@ -1,14 +1,17 @@
 #! /bin/bash
 
 # This script is used to manually prepare an Ubuntu 16.04 server for DetectionLab building
-
+export DEBIAN_FRONTEND=noninteractive
 sed -i 's/archive.ubuntu.com/us.archive.ubuntu.com/g' /etc/apt/sources.list
 
-# Install Virtualbox 5.2
-echo "deb http://download.virtualbox.org/virtualbox/debian xenial contrib" >> /etc/apt/sources.list
+# Install Virtualbox 6.1
+echo "deb [arch=amd64] https://download.virtualbox.org/virtualbox/debian $(lsb_release -sc) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
 wget -q https://www.virtualbox.org/download/oracle_vbox_2016.asc -O- | sudo apt-key add -
-apt-get update
-apt-get install -y linux-headers-"$(uname -r)" virtualbox-5.2 build-essential unzip git ufw apache2 python-pip
+wget -q https://www.virtualbox.org/download/oracle_vbox.asc -O- | sudo apt-key add -
+echo "[$(date +%H:%M:%S)]: Running apt-get update..."
+apt-get -qq update
+echo "[$(date +%H:%M:%S)]: Running apt-get install..."
+apt-get -qq install -y linux-headers-"$(uname -r)" virtualbox-6.1 build-essential unzip git ufw apache2 python-pip
 pip install awscli --upgrade --user
 cp /root/.local/bin/aws /usr/local/bin/aws && chmod +x /usr/local/bin/aws
 


### PR DESCRIPTION
* Remove WEF re-arm as this is done as part of the Vagrant provisioning now
* Add a remote-exec command to force win10 to reactivate after booting

```
aws_instance.win10 (remote-exec): C:\Users\vagrant>cscript c:\windows\system32\slmgr.vbs /ato
aws_instance.win10 (remote-exec): Microsoft (R) Windows Script Host Version 5.812
aws_instance.win10 (remote-exec): Copyright (C) Microsoft Corporation. All rights reserved.
aws_instance.win10 (remote-exec): Product activated successfully.
```
* Update manual machine bootstrap script to Virtualbox 6.1
