### PR TITLE
ESXi and Osquery Fixes

### DIFF
--- a/ESXi/ansible/roles/logger/tasks/main.yml
+++ b/ESXi/ansible/roles/logger/tasks/main.yml
@@ -340,8 +340,11 @@
     sed -i 's/interval: 28800/interval: 900/g' osquery-configuration/Fleet/Endpoints/MacOS/osquery.yaml
     sed -i 's/interval: 28800/interval: 900/g' osquery-configuration/Fleet/Endpoints/Windows/osquery.yaml
 
+    # Don't log osquery INFO messages
+    # Fix snapshot event formatting
     fleetctl get options > /tmp/options.yaml
     /usr/bin/yq w -i /tmp/options.yaml 'spec.config.options.logger_min_status' '1'
+    /usr/bin/yq w -i /tmp/options.yaml 'spec.config.options.logger_snapshot_event_type' '2'
     fleetctl apply -f /tmp/options.yaml
 
     # Use fleetctl to import YAML files

--- a/ESXi/main.tf
+++ b/ESXi/main.tf
@@ -72,7 +72,7 @@ resource "esxi_guest" "dc" {
   boot_disk_type = "thin"
   boot_disk_size = "35"
 
-  memsize            = "2048"
+  memsize            = "4096"
   numvcpus           = "2"
   resource_pool_name = "/"
   power              = "on"

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -267,6 +267,7 @@ import_osquery_config_into_fleet() {
   sed -i 's/interval: 28800/interval: 900/g' osquery-configuration/Fleet/Endpoints/Windows/osquery.yaml
 
   # Don't log osquery INFO messages
+  # Fix snapshot event formatting
   fleetctl get options > /tmp/options.yaml
   /usr/bin/yq w -i /tmp/options.yaml 'spec.config.options.logger_min_status' '1'
   /usr/bin/yq w -i /tmp/options.yaml 'spec.config.options.logger_snapshot_event_type' '2'

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -269,6 +269,7 @@ import_osquery_config_into_fleet() {
   # Don't log osquery INFO messages
   fleetctl get options > /tmp/options.yaml
   /usr/bin/yq w -i /tmp/options.yaml 'spec.config.options.logger_min_status' '1'
+  /usr/bin/yq w -i /tmp/options.yaml 'spec.config.options.logger_snapshot_event_type' '2'
   fleetctl apply -f /tmp/options.yaml
 
   # Use fleetctl to import YAML files

--- a/Vagrant/scripts/install-osquery.ps1
+++ b/Vagrant/scripts/install-osquery.ps1
@@ -26,6 +26,8 @@ If (-not ($service)) {
   (Get-Content "c:\Program Files\osquery\osquery.flags") -replace 'path\\to\\file\\containing\\secret.txt', 'Program Files\osquery\kolide_secret.txt' | Set-Content "c:\Program Files\osquery\osquery.flags"
   ## Change path to certfile
   (Get-Content "c:\Program Files\osquery\osquery.flags") -replace 'c:\\ProgramData\\osquery\\certfile.crt', 'c:\Program Files\osquery\certfile.crt' | Set-Content "c:\Program Files\osquery\osquery.flags"
+  ## Remove the verbose flag and replace it with the logger_min_status=1 option (See https://github.com/osquery/osquery/issues/5212)
+  (Get-Content "c:\Program Files\osquery\osquery.flags") -replace '--verbose=true', '--logger_min_status=1' | Set-Content "c:\Program Files\osquery\osquery.flags"
   ## Add certfile.crt
   Copy-Item "c:\vagrant\resources\fleet\server.crt" "c:\Program Files\osquery\certfile.crt"
   ## Start the service


### PR DESCRIPTION
- Fixes #455 by upping the ESXi DC host RAM to 4GB
- Adds a Fleet option to split snapshot events
- Remove the `--verbose` flag and add the `--logger_min_status=1` flag to the osquery.flags file