### PR TITLE
Don't change adapter DNS settings in Azure

### DIFF
--- a/Vagrant/scripts/create-domain.ps1
+++ b/Vagrant/scripts/create-domain.ps1
@@ -46,10 +46,12 @@ if ((gwmi win32_computersystem).partofdomain -eq $false) {
     -Force:$true
 
   $newDNSServers = "127.0.0.1", "8.8.8.8", "4.4.4.4"
+
   $adapters = Get-WmiObject Win32_NetworkAdapterConfiguration | Where-Object { $_.IPAddress -And ($_.IPAddress).StartsWith($subnet) }
   if ($adapters) {
     Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Setting DNS"
-    $adapters | ForEach-Object {$_.SetDNSServerSearchOrder($newDNSServers)}
+    # Don't do this in Azure. If the network adatper description contains "Hyper-V", this won't apply changes.
+    $adapters | ForEach-Object if (!($_.Description).Contains("Hyper-V")) {$_.SetDNSServerSearchOrder($newDNSServers)}
   }
   Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Setting timezone to UTC"
   c:\windows\system32\tzutil.exe /s "UTC"

--- a/Vagrant/scripts/create-domain.ps1
+++ b/Vagrant/scripts/create-domain.ps1
@@ -51,7 +51,7 @@ if ((gwmi win32_computersystem).partofdomain -eq $false) {
   if ($adapters) {
     Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Setting DNS"
     # Don't do this in Azure. If the network adatper description contains "Hyper-V", this won't apply changes.
-    $adapters | ForEach-Object if (!($_.Description).Contains("Hyper-V")) {$_.SetDNSServerSearchOrder($newDNSServers)}
+    $adapters | ForEach-Object {if (!($_.Description).Contains("Hyper-V")) {$_.SetDNSServerSearchOrder($newDNSServers)}}
   }
   Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Setting timezone to UTC"
   c:\windows\system32\tzutil.exe /s "UTC"

--- a/Vagrant/scripts/join-domain.ps1
+++ b/Vagrant/scripts/join-domain.ps1
@@ -6,7 +6,8 @@ Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Joining the domain..."
 Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) First, set DNS to DC to join the domain..."
 $newDNSServers = "192.168.38.102"
 $adapters = Get-WmiObject Win32_NetworkAdapterConfiguration | Where-Object {$_.IPAddress -match "192.168.38."}
-$adapters | ForEach-Object {$_.SetDNSServerSearchOrder($newDNSServers)}
+# Don't do this in Azure. If the network adatper description contains "Hyper-V", this won't apply changes.
+$adapters | ForEach-Object {if (!($_.Description).Contains("Hyper-V")) {$_.SetDNSServerSearchOrder($newDNSServers)}}
 
 Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Now join the domain..."
 $hostname = $(hostname)


### PR DESCRIPTION
Changing DNS settings while joining or creating the domain on Azure hosts terminates the connection. 