### PR TITLE
Fix #470

### DIFF
--- a/Vagrant/scripts/install-redteam.ps1
+++ b/Vagrant/scripts/install-redteam.ps1
@@ -12,7 +12,7 @@ If ($hostname -eq "win10") {
 }
 
 # Windows Defender should be disabled already by the GPO, sometimes it doesnt work
-If ($hostname -ne "win10") {
+If ($hostname -ne "win10" -And (Get-Service -Name WinDefend -ErrorAction SilentlyContinue).status -eq 'Running') {
   # Uninstalling Windows Defender (https://github.com/StefanScherer/packer-windows/issues/201)
   Uninstall-WindowsFeature Windows-Defender
   Uninstall-WindowsFeature Windows-Defender-Features


### PR DESCRIPTION
Make sure WinDefend service is not running when uninstalling `Windows-Defender` and `Windows-Defender-Features` via install-redteam.ps1 script.