### PR TITLE
Catch both of 0xC004D302 and 0xC004FC07 codes while activation

### DIFF
--- a/Vagrant/scripts/fix-windows-expiration.ps1
+++ b/Vagrant/scripts/fix-windows-expiration.ps1
@@ -1,8 +1,8 @@
 # Purpose: Re-arms the expiration timer on expiring Windows eval images and fixes activation issues
 
 # Check to see if there are days left on the timer or if it's just expired
-$regex = cscript c:\windows\system32\slmgr.vbs /dlv | select-string -Pattern "\((\d+) day\(s\)|grace time expired"
-if ($regex.Matches.Value -eq "grace time expired") {
+$regex = cscript c:\windows\system32\slmgr.vbs /dlv | select-string -Pattern "\((\d+) day\(s\)|grace time expired|0xC004D302|0xC004FC07"
+if ($regex.Matches.Value -eq "grace time expired" -or $regex.Matches.Value -eq "0xC004D302") {
   # If it shows expired, it's likely it wasn't properly activated
   Write-Host "It appears Windows was not properly activated. Attempting to resolve..."
   try {
@@ -15,22 +15,42 @@ if ($regex.Matches.Value -eq "grace time expired") {
   } catch {
     Write-Host "Something went wrong trying to reactivate Windows..."
   }
+
+  # That happens on Windows 10
+  } elseif ($regex.Matches.Value -eq "0xC004FC07") {
+    try {
+      cscript c:\windows\system32\slmgr.vbs /rearm
+    } catch {
+      Write-Host "Something went wrong trying to re-arm the image..."
+    }
+  }
+
   # If activation was successful, the regex should match 90 or 180 (Win10 or Win2016)
   $regex = cscript c:\windows\system32\slmgr.vbs /dlv | select-string -Pattern "\((\d+) day\(s\)"
-}  
-try {
-  $days_left = $regex.Matches.Groups[1].Value
-} catch {
-  Write-Host "Unable to successfully parse the output from slmgr, not rearming"
-  $days_left = 90
-}
+  try {
+    $days_left = $regex.Matches.Groups[1].Value
+  } catch {
+    Write-Host "Unable to successfully parse the output from slmgr, not rearming"
+    $days_left = 90
+  }
 
 if ($days_left -as [int] -lt 30) {
   write-host "Less than 30 days remaining before Windows expiration. Attempting to rearm..."
+  # That block to trigger on 0xC004D302 error code
   try {
-    cscript c:\windows\system32\slmgr.vbs /rearm
+    # cscript c:\windows\system32\slmgr.vbs /rearm
+    # The TrustedInstaller service MUST be running for activation to succeed
+    Set-Service TrustedInstaller -StartupType Automatic
+    Start-Service TrustedInstaller
+    Start-Sleep 10
+    # Attempt to activate
+    cscript c:\windows\system32\slmgr.vbs /ato
   } catch {
-    Write-Host "Something went wrong trying to re-arm the image..."
+    try {
+      cscript c:\windows\system32\slmgr.vbs /rearm
+    } catch {
+      Write-Host "Something went wrong trying to re-arm the image..."
+    }
   }
 } else {
   Write-Host "$days_left days left until expiration, no need to rearm."


### PR DESCRIPTION
I've faced an issue with windows activation on both of WEF and Win10 after I packed them, was able to get around it by catching both of `0xC004D302` and `0xC004FC07` codes and update the logic in fix-windows-expiration.ps1 script.

<img width="1388" alt="Screenshot 2020-06-25 01 46 20" src="https://user-images.githubusercontent.com/1170490/85719359-67592580-b700-11ea-963d-0f3a8604e5be.png">
