### PR TITLE
Variables for improved resource tagging

### DIFF
--- a/AWS/Terraform/main.tf
+++ b/AWS/Terraform/main.tf
@@ -159,7 +159,7 @@ resource "aws_instance" "logger" {
   ami           = coalesce(var.logger_ami, data.aws_ami.logger_ami.image_id)
 
   tags = {
-    Name = "logger"
+    Name = "${var.tag_prefix}logger"
   }
 
   subnet_id              = aws_subnet.default.id
@@ -223,7 +223,7 @@ resource "aws_instance" "dc" {
   ami = coalesce(var.dc_ami, data.aws_ami.dc_ami.image_id)
 
   tags = {
-    Name = "dc.windomain.local"
+    Name = "${var.tag_prefix}dc.windomain.local"
   }
 
   subnet_id              = aws_subnet.default.id
@@ -258,7 +258,7 @@ resource "aws_instance" "wef" {
   ami = coalesce(var.wef_ami, data.aws_ami.wef_ami.image_id)
 
   tags = {
-    Name = "wef.windomain.local"
+    Name = "${var.tag_prefix}wef.windomain.local"
   }
 
   subnet_id              = aws_subnet.default.id
@@ -293,7 +293,7 @@ resource "aws_instance" "win10" {
   ami = coalesce(var.win10_ami, data.aws_ami.win10_ami.image_id)
 
   tags = {
-    Name = "win10.windomain.local"
+    Name = "${var.tag_prefix}win10.windomain.local"
   }
 
   subnet_id              = aws_subnet.default.id
@@ -304,4 +304,3 @@ resource "aws_instance" "win10" {
     delete_on_termination = true
   }
 }
-

--- a/AWS/Terraform/main.tf
+++ b/AWS/Terraform/main.tf
@@ -166,7 +166,7 @@ resource "aws_instance" "logger" {
   ami           = coalesce(var.logger_ami, data.aws_ami.logger_ami.image_id)
 
   tags = merge(var.custom-tags, map(
-    "Name", "${var.tag_prefix}logger"
+    "Name", "${var.instance_name_prefix}logger"
   ))
 
   subnet_id              = aws_subnet.default.id
@@ -230,7 +230,7 @@ resource "aws_instance" "dc" {
   ami = coalesce(var.dc_ami, data.aws_ami.dc_ami.image_id)
 
   tags = merge(var.custom-tags, map(
-    "Name", "${var.tag_prefix}dc.windomain.local"
+    "Name", "${var.instance_name_prefix}dc.windomain.local"
   ))
 
   subnet_id              = aws_subnet.default.id
@@ -265,7 +265,7 @@ resource "aws_instance" "wef" {
   ami = coalesce(var.wef_ami, data.aws_ami.wef_ami.image_id)
 
   tags = merge(var.custom-tags, map(
-    "Name", "${var.tag_prefix}wef.windomain.local"
+    "Name", "${var.instance_name_prefix}wef.windomain.local"
   ))
 
   subnet_id              = aws_subnet.default.id
@@ -300,7 +300,7 @@ resource "aws_instance" "win10" {
   ami = coalesce(var.win10_ami, data.aws_ami.win10_ami.image_id)
 
   tags = merge(var.custom-tags, map(
-    "Name", "${var.tag_prefix}win10.windomain.local"
+    "Name", "${var.instance_name_prefix}win10.windomain.local"
   ))
 
   subnet_id              = aws_subnet.default.id

--- a/AWS/Terraform/terraform.tfvars.example
+++ b/AWS/Terraform/terraform.tfvars.example
@@ -7,3 +7,4 @@ private_key_path = "/home/user/.ssh/id_logger"
 ip_whitelist = ["1.2.3.4/32"]
 availability_zone = "us-west-1b"
 // tag_prefix = "some_prefix_"
+// custom-tags = {"tag_name": "tag_value"}

--- a/AWS/Terraform/terraform.tfvars.example
+++ b/AWS/Terraform/terraform.tfvars.example
@@ -6,3 +6,4 @@ public_key_path = "/home/user/.ssh/id_logger.pub"
 private_key_path = "/home/user/.ssh/id_logger"
 ip_whitelist = ["1.2.3.4/32"]
 availability_zone = "us-west-1b"
+// tag_prefix = "some_prefix_"

--- a/AWS/Terraform/terraform.tfvars.example
+++ b/AWS/Terraform/terraform.tfvars.example
@@ -6,5 +6,5 @@ public_key_path = "/home/user/.ssh/id_logger.pub"
 private_key_path = "/home/user/.ssh/id_logger"
 ip_whitelist = ["1.2.3.4/32"]
 availability_zone = "us-west-1b"
-// tag_prefix = "some_prefix_"
+// instance_name_prefix = "some_prefix_"
 // custom-tags = {"tag_name": "tag_value"}

--- a/AWS/Terraform/variables.tf
+++ b/AWS/Terraform/variables.tf
@@ -12,7 +12,7 @@ variable "custom-tags" {
   default = {}
 }
 
-variable "tag_prefix" {
+variable "instance_name_prefix" {
   description = "Optional string to prefix at the front of instance names in case you need to run multiple DetectionLab environments in the same AWS account"
   default     = ""
 }
@@ -120,4 +120,3 @@ variable "win10_ami" {
   type    = string
   default = ""
 }
-

--- a/AWS/Terraform/variables.tf
+++ b/AWS/Terraform/variables.tf
@@ -6,6 +6,11 @@ variable "profile" {
   default = "terraform"
 }
 
+variable "tag_prefix" {
+  description = "Optional string to prefix at the front of instance names in case you need to run multiple DetectionLab environments in the same AWS account"
+  default     = ""
+}
+
 variable "availability_zone" {
   description = "https://www.terraform.io/docs/providers/aws/d/availability_zone.html"
   default     = ""

--- a/AWS/Terraform/variables.tf
+++ b/AWS/Terraform/variables.tf
@@ -6,6 +6,12 @@ variable "profile" {
   default = "terraform"
 }
 
+variable "custom-tags" {
+  type = map(string)
+  description = "Optional mapping for additional tags to apply to all related AWS resources"
+  default = {}
+}
+
 variable "tag_prefix" {
   description = "Optional string to prefix at the front of instance names in case you need to run multiple DetectionLab environments in the same AWS account"
   default     = ""


### PR DESCRIPTION
Two new optional variables for improving tagging of AWS resources:
* instance_name_prefix: string to append to the front of the name of each new instance created. This will help keep instances distinct if more than one DetectionLab environment is created within a single AWS account.
* custom-tags: map of names & values for tags to apply to all resources created in AWS