### PR TITLE
Fix Cloud ingress rules, re-write vm-guest-tools to powershell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Boxes/*
 *.tfstate.*
 *.tfvars
 inventory.yml
+inventory.yml.bak
+*.box
+manifest.xml

--- a/AWS/Terraform/main.tf
+++ b/AWS/Terraform/main.tf
@@ -91,6 +91,14 @@ resource "aws_security_group" "logger" {
     cidr_blocks = var.ip_whitelist
   }
 
+  # Velociraptor access
+    ingress {
+    from_port   = 9999
+    to_port     = 9999
+    protocol    = "tcp"
+    cidr_blocks = var.ip_whitelist
+  }
+
   # Allow all traffic from the private subnet
   ingress {
     from_port   = 0

--- a/Azure/Terraform/main.tf
+++ b/Azure/Terraform/main.tf
@@ -150,6 +150,19 @@ resource "azurerm_network_security_group" "detectionlab-nsg" {
     source_address_prefixes    = var.ip_whitelist
     destination_address_prefix = "*"
   }
+
+  # Velociraptor access
+  security_rule {
+    name                       = "Velociraptor"
+    priority                   = 1009
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "9999"
+    source_address_prefixes    = var.ip_whitelist
+    destination_address_prefix = "*"
+  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "detectionlab-nsga" {

--- a/Packer/scripts/vm-guest-tools.ps1
+++ b/Packer/scripts/vm-guest-tools.ps1
@@ -1,0 +1,77 @@
+if (!( Test-Path "C:\Windows\Temp\7z1900-x64.msi")) {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')
+}
+if (!(Test-Path "C:\Windows\Temp\7z1900-x64.msi")) {
+  Start-Sleep 5; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')
+}
+cmd /c msiexec /qb /i C:\Windows\Temp\7z1900-x64.msi
+
+if ("$env:PACKER_BUILDER_TYPE" -eq "vmware-iso") {
+
+    Write-Host "Using VMware"
+    if (Test-Path "C:\Users\vagrant\windows.iso") {
+        Move-Item -force C:\Users\vagrant\windows.iso C:\Windows\Temp
+    }
+
+    if (!(Test-Path "C:\Windows\Temp\windows.iso")) {
+        Try {
+            $pageContentLinks = (Invoke-WebRequest('https://softwareupdate.vmware.com/cds/vmw-desktop/ws') -UseBasicParsing).Links | where-object {$_.href -Match "[0-9]"} | Select-Object href | % { $_.href.Trim('/') }
+            $versionObject = $pageContentLinks | %{ new-object System.Version ($_) } | sort-object -Descending | select-object -First 1 -Property:Major,Minor,Build
+            $newestVersion = $versionObject.Major.ToString()+"."+$versionObject.Minor.ToString()+"."+$versionObject.Build.ToString() | out-string
+            $newestVersion = $newestVersion.TrimEnd("`r?`n")
+
+            $nextURISubdirectoryObject = (Invoke-WebRequest("https://softwareupdate.vmware.com/cds/vmw-desktop/ws/$newestVersion/") -UseBasicParsing).Links | where-object {$_.href -Match "[0-9]"} | Select-Object href | where-object {$_.href -Match "[0-9]"}
+            $nextUriSubdirectory = $nextURISubdirectoryObject.href | Out-String
+            $nextUriSubdirectory = $nextUriSubdirectory.TrimEnd("`r?`n") 
+            $newestVMwareToolsURL = "https://softwareupdate.vmware.com/cds/vmw-desktop/ws/$newestVersion/$nextURISubdirectory/windows/packages/tools-windows.tar"
+            Write-Host "The latest version of VMware tools has been determined to be downloadable from $newestVMwareToolsURL"
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile("$newestVMwareToolsURL", 'C:\Windows\Temp\vmware-tools.tar')
+        } Catch {
+            Write-Host "Unable to determine the latest version of VMware tools. Falling back to hardcoded URL."
+            (New-Object System.Net.WebClient).DownloadFile('https://softwareupdate.vmware.com/cds/vmw-desktop/ws/15.5.5/16285975/windows/packages/tools-windows.tar', 'C:\Windows\Temp\vmware-tools.tar')
+        }
+        cmd /c "C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\vmware-tools.tar -oC:\Windows\Temp 
+        Move-Item c:\windows\temp\VMware-tools-windows-*.iso c:\windows\temp\windows.iso
+        Try { Remove-Item "C:\Program Files (x86)\VMWare" -Recurse -Force -ErrorAction Stop } Catch { Write-Host "Directory didn't exist to be removed." }
+    }
+
+    cmd /c "C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\windows.iso" -oC:\Windows\Temp\VMWare
+    cmd /c C:\Windows\Temp\VMWare\setup.exe /S /v"/qn REBOOT=R\"
+
+    Remove-Item -Force "C:\Windows\Temp\vmware-tools.tar"
+    Remove-Item -Force "C:\Windows\Temp\windows.iso"
+    Remove-Item -Force -Recurse "C:\Windows\Temp\VMware"
+}
+
+if ("$env:PACKER_BUILDER_TYPE" -eq "virtualbox-iso") {
+    Write-Host "Using Virtualbox"
+    if (Test-Path "C:\Users\vagrant\VBoxGuestAdditions.iso") {
+        Move-Item -Force C:\Users\vagrant\VBoxGuestAdditions.iso C:\Windows\Temp
+    }
+
+    if (!(Test-Path "C:\Windows\Temp\VBoxGuestAdditions.iso")) {
+        Try {
+            $pageContentLinks = (Invoke-WebRequest('https://download.virtualbox.org/virtualbox') -UseBasicParsing).Links | where-object {$_.href -Match "[0-9]"} | Select-Object href |  where-object {$_.href -NotMatch "BETA"} |  where-object {$_.href -NotMatch "RC"} |   where-object {$_.href -Match "[0-9]\.[0-9]"} | % { $_.href.Trim('/') }
+            $versionObject = $pageContentLinks | %{ new-object System.Version ($_) } | sort-object -Descending | select-object -First 1 -Property:Major,Minor,Build
+            $newestVersion = $versionObject.Major.ToString()+"."+$versionObject.Minor.ToString()+"."+$versionObject.Build.ToString() | out-string
+            $newestVersion = $newestVersion.TrimEnd("`r?`n")
+
+            $nextURISubdirectoryObject = (Invoke-WebRequest("https://download.virtualbox.org/virtualbox/$newestVersion/") -UseBasicParsing).Links | Select-Object href | where-object {$_.href -Match "GuestAdditions"}
+            $nextUriSubdirectory = $nextURISubdirectoryObject.href | Out-String
+            $nextUriSubdirectory = $nextUriSubdirectory.TrimEnd("`r?`n")
+            $newestVboxToolsURL = "https://download.virtualbox.org/virtualbox/$newestVersion/$nextUriSubdirectory"
+            Write-Host "The latest version of VirtualBox tools has been determined to be downloadable from $newestVboxToolsURL"
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile("$newestVboxToolsURL", 'C:\Windows\Temp\VBoxGuestAdditions.iso')
+        } Catch {
+            Write-Host "Unable to determine the latest version of VBox tools. Falling back to hardcoded URL."
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://download.virtualbox.org/virtualbox/6.1.8/VBoxGuestAdditions_6.1.8.iso', 'C:\Windows\Temp\VBoxGuestAdditions.iso')
+        }
+    }
+
+    cmd /c ""C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\VBoxGuestAdditions.iso -oC:\Windows\Temp\virtualbox"
+    cmd /c for %%i in (C:\Windows\Temp\virtualbox\cert\vbox*.cer) do C:\Windows\Temp\virtualbox\cert\VBoxCertUtil add-trusted-publisher %%i --root %%i
+    cmd /c C:\Windows\Temp\virtualbox\VBoxWindowsAdditions.exe /S
+    cmd /c rd /S /Q "C:\Windows\Temp\virtualbox"
+}
+
+cmd /c msiexec /qb /x C:\Windows\Temp\7z1900-x64.msi

--- a/Packer/windows_10.json
+++ b/Packer/windows_10.json
@@ -144,13 +144,13 @@
       "remote_path": "/tmp/script.bat",
       "execute_command": "{{ .Vars }} cmd /c \"{{ .Path }}\"",
       "scripts": [
-        "./scripts/vm-guest-tools.bat",
         "./scripts/enable-rdp.bat"
       ]
     },
     {
       "type": "powershell",
       "scripts": [
+        "./scripts/vm-guest-tools.ps1",
         "./scripts/debloat-windows.ps1"
       ]
     },

--- a/Packer/windows_2016.json
+++ b/Packer/windows_2016.json
@@ -135,13 +135,13 @@
       "type": "windows-shell",
       "execute_command": "{{ .Vars }} cmd /c \"{{ .Path }}\"",
       "scripts": [
-        "./scripts/vm-guest-tools.bat",
         "./scripts/enable-rdp.bat"
       ]
     },
     {
       "type": "powershell",
       "scripts": [
+        "./scripts/vm-guest-tools.ps1",
         "./scripts/debloat-windows.ps1"
       ]
     },


### PR DESCRIPTION
- Update .gitignore
- Allow access to Velociraptor for Azure and AWS
- Re-write vm-guest-tools.bat in Powershell
   - Dynamically resolve the latest guest tools