### PR TITLE
Fixes for Fleet 3.0

### DIFF
--- a/Vagrant/resources/fleet/fleet.service
+++ b/Vagrant/resources/fleet/fleet.service
@@ -3,7 +3,7 @@ Description=Kolide Fleet
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/fleet serve --mysql_address=127.0.0.1:3306 --mysql_database=kolide --mysql_username=root --mysql_password=kolide --redis_address=127.0.0.1:6379  --server_cert=/opt/fleet/server.crt --server_key=/opt/fleet/server.key --logging_json --osquery_result_log_file=/var/log/kolide/osquery_result  --osquery_status_log_file=/var/log/kolide/osquery_status --auth_jwt_key=dasdsadasdjhshgfhdfb --server_address 0.0.0.0:8412 --osquery_enable_log_rotation
+ExecStart=/usr/local/bin/fleet serve --mysql_address=127.0.0.1:3306 --mysql_database=kolide --mysql_username=root --mysql_password=kolide --redis_address=127.0.0.1:6379  --server_cert=/opt/fleet/server.crt --server_key=/opt/fleet/server.key --logging_json --osquery_result_log_file=/var/log/fleet/osquery_result  --osquery_status_log_file=/var/log/fleet/osquery_status --auth_jwt_key=dasdsadasdjhshgfhdfb --server_address 0.0.0.0:8412 --osquery_enable_log_rotation
 
 [Install]
 WantedBy=multi-user.target

--- a/build.ps1
+++ b/build.ps1
@@ -304,7 +304,7 @@ function vagrant_up_host {
   Write-Host "Attempting to bring up the $VagrantHost host using Vagrant" -ForegroundColor green
   $CurrentDir = Get-Location
   Set-Location "$DL_DIR\Vagrant"
-  set VAGRANT_LOG=info
+  Set-Variable VAGRANT_LOG=info
   &vagrant.exe @('up', $VagrantHost, '--provider', "$ProviderName") 2>&1 | Out-File -FilePath ".\vagrant_up_$VagrantHost.log"
   Set-Location $CurrentDir
   Write-Host "[vagrant_up_host] Finished for $VagrantHost. Got exit code: $LASTEXITCODE" -ForegroundColor green


### PR DESCRIPTION
- Remove docker installation (no longer needed)
- Fixing #487 
- Changing log directory to `/var/log/fleet` from `/var/log/kolide`
- Fix logger snapshot event type option application
- Fleet installation will dynamically grab the latest release
- Fixed the Splunk monitors