### PR TITLE
ESXi: Add missing commands for splunk ThreatHunting app that existed in vagrant bootstrap file

### DIFF
--- a/ESXi/ansible/roles/logger/tasks/main.yml
+++ b/ESXi/ansible/roles/logger/tasks/main.yml
@@ -231,8 +231,17 @@
         sed -i "s/license_key =/license_key = $MAXMIND_LICENSE/g" /opt/splunk/etc/apps/TA-asngen/local/asngen.conf
       fi
 
+      # Replace the props.conf for Sysmon TA and Windows TA
+      # Removed all the 'rename = xmlwineventlog' directives
+      # I know youre not supposed to modify files in "default",
+      # but for some reason adding them to "local" wasnt working
+      cp /vagrant/resources/splunk_server/windows_ta_props.conf /opt/splunk/etc/apps/Splunk_TA_windows/default/props.conf
+      cp /vagrant/resources/splunk_server/sysmon_ta_props.conf /opt/splunk/etc/apps/TA-microsoft-sysmon/default/props.conf
+
       # Add custom Macro definitions for ThreatHunting App
       cp /vagrant/resources/splunk_server/macros.conf /opt/splunk/etc/apps/ThreatHunting/default/macros.conf
+      # Fix props.conf in ThreatHunting App
+      sed -i 's/EVAL-host_fqdn = Computer/EVAL-host_fqdn = ComputerName/g' /opt/splunk/etc/apps/ThreatHunting/default/props.conf
       # Fix Windows TA macros
       mkdir /opt/splunk/etc/apps/Splunk_TA_windows/local
       cp /opt/splunk/etc/apps/Splunk_TA_windows/default/macros.conf /opt/splunk/etc/apps/Splunk_TA_windows/local


### PR DESCRIPTION
When comparing ./ESXi/ansible/roles/logger/tasks/main.yml with ./Vagrant/bootstrap.sh, there are a few critical commands that were missing including the removal all the 'rename = xmlwineventlog' directives in prop files for window and sysmon TA apps. The other item is the command for correcting hostnames in the props.conf for the threathunting app.

Without these changes, the threathunting app index wasn't getting populated and malicious actions weren't getting caught, rendering the app useless.