### PR TITLE
Make DetectionLab work on FreeBSD

### DIFF
--- a/Vagrant/prepare.sh
+++ b/Vagrant/prepare.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # This script is meant to verify that your system is configured to 
 # build DetectionLab successfully.


### PR DESCRIPTION
FreeBSD doesn't ship with bash by default. However, if one installs bash via `pkg install`, it will end up at `/usr/local/bin/bash` which the current shebang doesn't catch. Using `/usr/bin/env bash` instead makes it work on other Unixes as well.