### PR TITLE
ESXi Bugfixes - Use only 2 network adapters instead of 3

### DIFF
--- a/ESXi/ansible/roles/dc/tasks/main.yml
+++ b/ESXi/ansible/roles/dc/tasks/main.yml
@@ -10,10 +10,10 @@
   when: res.reboot_required
 
 - name: Set HostOnly IP Address
-  win_shell: "New-NetIPAddress –InterfaceAlias Ethernet2 –AddressFamily IPv4 -IPAddress 192.168.38.102 –PrefixLength 24 -DefaultGateway 192.168.38.1"
+  win_shell: "New-NetIPAddress –InterfaceAlias Ethernet1 –AddressFamily IPv4 -IPAddress 192.168.38.102 –PrefixLength 24 -DefaultGateway 192.168.38.1"
 
 - name: Set DNS Address
-  win_shell: "Set-DnsClientServerAddress -InterfaceAlias Ethernet2 -ServerAddresses 127.0.0.1,8.8.8.8"
+  win_shell: "Set-DnsClientServerAddress -InterfaceAlias Ethernet1 -ServerAddresses 127.0.0.1,8.8.8.8"
 
 - name: Install git
   win_chocolatey:

--- a/ESXi/ansible/roles/logger/tasks/main.yml
+++ b/ESXi/ansible/roles/logger/tasks/main.yml
@@ -219,11 +219,6 @@
       /opt/splunk/bin/splunk install app /vagrant/resources/splunk_server/link-analysis-app-for-splunk_161.tgz -auth 'admin:changeme'
       /opt/splunk/bin/splunk install app /vagrant/resources/splunk_server/threathunting_144.tgz -auth 'admin:changeme'
 
-      ## Fix a bug with the ThreatHunting App (https://github.com/olafhartong/ThreatHunting/pull/57)
-      mv /opt/splunk/etc/apps/ThreatHunting/lookups/sysmonevencodes.csv /opt/splunk/etc/apps/ThreatHunting/lookups/sysmoneventcodes.csv
-      sed -i 's/= sysmoneventcode /= sysmoneventcodes.csv /g' /opt/splunk/etc/apps/ThreatHunting/default/props.conf
-      sed -i 's/sysmoneventcode.csv/sysmoneventcodes.csv/g' /opt/splunk/etc/apps/ThreatHunting/default/props.conf
-
       # Install the Maxmind license key for the ASNgen App
       if [ ! -z $MAXMIND_LICENSE ]; then
         mkdir /opt/splunk/etc/apps/TA-asngen/local 
@@ -272,8 +267,6 @@
       dismissedInstrumentationOptInVersion = 4
       notification_python_3_impact = false
       display.page.home.dashboardId = /servicesNS/nobody/search/data/ui/views/logger_dashboard' > /opt/splunk/etc/users/admin/user-prefs/local/user-prefs.conf
-      # Disable the instrumentation popup
-      echo -e "showOptInModal = 0\noptInVersionAcknowledged = 4" >>/opt/splunk/etc/apps/splunk_instrumentation/local/telemetry.conf
       # Enable SSL Login for Splunk
       echo -e "[settings]\nenableSplunkWebSSL = true" >/opt/splunk/etc/system/local/web.conf
       # Copy over the Logger Dashboard
@@ -284,8 +277,6 @@
       # Reboot Splunk to make changes take effect
         /opt/splunk/bin/splunk restart
         /opt/splunk/bin/splunk enable boot-start
-        # Generate the ASN lookup table
-        /opt/splunk/bin/splunk search "|asngen | outputlookup asn" -auth 'admin:changeme'
       fi
   register: install_splunk
   changed_when: "'The Splunk web interface is at https://logger:8000' in install_splunk.stdout"

--- a/ESXi/ansible/roles/wef/tasks/main.yml
+++ b/ESXi/ansible/roles/wef/tasks/main.yml
@@ -11,11 +11,11 @@
 
 # This needs to be made idempodent
 - name: Set HostOnly IP Address
-  win_shell: "New-NetIPAddress –InterfaceAlias Ethernet2 –AddressFamily IPv4 -IPAddress 192.168.38.103 –PrefixLength 24 -DefaultGateway 192.168.38.1"
+  win_shell: "New-NetIPAddress –InterfaceAlias Ethernet1 –AddressFamily IPv4 -IPAddress 192.168.38.103 –PrefixLength 24 -DefaultGateway 192.168.38.1"
 
 # This needs to be made idempodent
 - name: Set HostOnly DNS Address
-  win_shell: "Set-DnsClientServerAddress -InterfaceAlias Ethernet2 -ServerAddresses 192.168.38.102,8.8.8.8"
+  win_shell: "Set-DnsClientServerAddress -InterfaceAlias Ethernet1 -ServerAddresses 192.168.38.102,8.8.8.8"
 
 - name: Install git
   win_chocolatey:

--- a/ESXi/ansible/roles/win10/tasks/main.yml
+++ b/ESXi/ansible/roles/win10/tasks/main.yml
@@ -10,10 +10,10 @@
   when: res.reboot_required
 
 - name: Set HostOnly IP Address
-  win_shell: "New-NetIPAddress –InterfaceAlias Ethernet2 –AddressFamily IPv4 -IPAddress 192.168.38.104 –PrefixLength 24 -DefaultGateway 192.168.38.1"
+  win_shell: "New-NetIPAddress –InterfaceAlias Ethernet1 –AddressFamily IPv4 -IPAddress 192.168.38.104 –PrefixLength 24 -DefaultGateway 192.168.38.1"
 
 - name: Set HostOnly DNS Address
-  win_shell: "Set-DnsClientServerAddress -InterfaceAlias Ethernet2 -ServerAddresses 192.168.38.102,8.8.8.8"
+  win_shell: "Set-DnsClientServerAddress -InterfaceAlias Ethernet1 -ServerAddresses 192.168.38.102,8.8.8.8"
 
 - name: Install git
   win_chocolatey:

--- a/ESXi/main.tf
+++ b/ESXi/main.tf
@@ -86,12 +86,6 @@ resource "esxi_guest" "dc" {
     mac_address     = "00:50:56:a1:b1:c2"
     nic_type        = "e1000"
   }
-  # OPTIONAL: You can comment out this interface stanza if your vm_network provides internet access
-  network_interfaces {
-    virtual_network = var.nat_network
-    mac_address     = "00:50:56:a1:b1:c3"
-    nic_type        = "e1000"
-  }
   # This is the local network that will be used for 192.168.38.x addressing
   network_interfaces {
     virtual_network = var.hostonly_network
@@ -121,12 +115,6 @@ resource "esxi_guest" "wef" {
     mac_address     = "00:50:56:a1:b2:c2"
     nic_type        = "e1000"
   }
-  # OPTIONAL: You can comment out this interface stanza if your vm_network provides internet access
-  network_interfaces {
-    virtual_network = var.nat_network
-    mac_address     = "00:50:56:a1:b3:c3"
-    nic_type        = "e1000"
-  }
   # This is the local network that will be used for 192.168.38.x addressing
   network_interfaces {
     virtual_network = var.hostonly_network
@@ -154,12 +142,6 @@ resource "esxi_guest" "win10" {
   network_interfaces {
     virtual_network = var.vm_network
     mac_address     = "00:50:56:a2:b1:c2"
-    nic_type        = "e1000"
-  }
-  # OPTIONAL: You can comment out this interface stanza if your vm_network provides internet access
-  network_interfaces {
-    virtual_network = var.nat_network
-    mac_address     = "00:50:56:a2:b1:c3"
     nic_type        = "e1000"
   }
   # This is the local network that will be used for 192.168.38.x addressing

--- a/ESXi/variables.tf
+++ b/ESXi/variables.tf
@@ -22,10 +22,6 @@ variable "vm_network" {
   default = "VM Network"
 }
 
-variable "nat_network" {
-  default = "NAT Network"
-}
-
 variable "hostonly_network" {
   default = "HostOnly Network"
 }


### PR DESCRIPTION
- Remove the 3rd "NAT Network" adapter as it's unnecessary and adds complexity
- Corrects the Windows network adapter name when only 2 adapters are created 
- Fix Splunk install Ansible task