### PR TITLE
ensure all resources utilize the vars.esxi_datastore var

### DIFF
--- a/ESXi/main.tf
+++ b/ESXi/main.tf
@@ -68,7 +68,7 @@ resource "esxi_guest" "logger" {
 
 resource "esxi_guest" "dc" {
   guest_name = "dc"
-  disk_store = "datastore2"
+  disk_store = var.esxi_datastore
   guestos    = "windows9srv-64"
 
   boot_disk_type = "thin"
@@ -97,7 +97,7 @@ resource "esxi_guest" "dc" {
 
 resource "esxi_guest" "wef" {
   guest_name = "wef"
-  disk_store = "datastore2"
+  disk_store = var.esxi_datastore
   guestos    = "windows9srv-64"
 
   boot_disk_type = "thin"
@@ -126,7 +126,7 @@ resource "esxi_guest" "wef" {
 
 resource "esxi_guest" "win10" {
   guest_name = "win10"
-  disk_store = "datastore2"
+  disk_store = var.esxi_datastore
   guestos    = "windows9-64"
 
   boot_disk_type = "thin"


### PR DESCRIPTION
experienced an issue where datastore2 was attempted to be used to create resources