### PR TITLE
Don't sync VM clock with ESXi host

### DIFF
--- a/ESXi/main.tf
+++ b/ESXi/main.tf
@@ -18,6 +18,16 @@ resource "esxi_guest" "logger" {
   guest_name = "logger"
   disk_store = var.esxi_datastore
   guestos    = "ubuntu-64"
+  custom_vmx_settings = [
+    ['tools.syncTime', '0'], 
+    ['time.synchronize.continue', '0'], 
+    ['time.synchronize.restore', '0'], 
+    ['time.synchronize.resume.disk', '0'], 
+    ['time.synchronize.shrink', '0'],
+    ['time.synchronize.tools.startup', '0'],
+    ['time.synchronize.tools.enable', '0'],
+    ['time.synchronize.resume.host', '0']
+  ]
 
   boot_disk_type = "thin"
 
@@ -70,9 +80,18 @@ resource "esxi_guest" "dc" {
   guest_name = "dc"
   disk_store = var.esxi_datastore
   guestos    = "windows9srv-64"
+  custom_vmx_settings = [
+    ['tools.syncTime', '0'], 
+    ['time.synchronize.continue', '0'], 
+    ['time.synchronize.restore', '0'], 
+    ['time.synchronize.resume.disk', '0'], 
+    ['time.synchronize.shrink', '0'],
+    ['time.synchronize.tools.startup', '0'],
+    ['time.synchronize.tools.enable', '0'],
+    ['time.synchronize.resume.host', '0']
+  ]
 
   boot_disk_type = "thin"
-  boot_disk_size = "35"
 
   memsize            = "4096"
   numvcpus           = "2"
@@ -99,9 +118,18 @@ resource "esxi_guest" "wef" {
   guest_name = "wef"
   disk_store = var.esxi_datastore
   guestos    = "windows9srv-64"
+  custom_vmx_settings = [
+    ['tools.syncTime', '0'], 
+    ['time.synchronize.continue', '0'], 
+    ['time.synchronize.restore', '0'], 
+    ['time.synchronize.resume.disk', '0'], 
+    ['time.synchronize.shrink', '0'],
+    ['time.synchronize.tools.startup', '0'],
+    ['time.synchronize.tools.enable', '0'],
+    ['time.synchronize.resume.host', '0']
+  ]
 
   boot_disk_type = "thin"
-  boot_disk_size = "35"
 
   memsize            = "2048"
   numvcpus           = "2"
@@ -128,9 +156,18 @@ resource "esxi_guest" "win10" {
   guest_name = "win10"
   disk_store = var.esxi_datastore
   guestos    = "windows9-64"
+  custom_vmx_settings = [
+    ['tools.syncTime', '0'], 
+    ['time.synchronize.continue', '0'], 
+    ['time.synchronize.restore', '0'], 
+    ['time.synchronize.resume.disk', '0'], 
+    ['time.synchronize.shrink', '0'],
+    ['time.synchronize.tools.startup', '0'],
+    ['time.synchronize.tools.enable', '0'],
+    ['time.synchronize.resume.host', '0']
+  ]
 
   boot_disk_type = "thin"
-  boot_disk_size = "35"
 
   memsize            = "2048"
   numvcpus           = "2"

--- a/ci/build_machine_bootstrap.sh
+++ b/ci/build_machine_bootstrap.sh
@@ -79,8 +79,8 @@ ufw --force enable
 echo "[$(date +%H:%M:%S)]: Installing Vagrant..."
 mkdir /opt/vagrant
 cd /opt/vagrant || exit 1
-wget --progress=bar:force https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.deb
-dpkg -i vagrant_2.2.10_x86_64.deb
+wget --progress=bar:force https://releases.hashicorp.com/vagrant/2.2.14/vagrant_2.2.14_x86_64.deb
+dpkg -i vagrant_2.2.14_x86_64.deb
 echo "[$(date +%H:%M:%S)]: Installing vagrant-reload plugin..."
 vagrant plugin install vagrant-reload
 

--- a/ci/manual_machine_bootstrap.sh
+++ b/ci/manual_machine_bootstrap.sh
@@ -25,8 +25,8 @@ git clone https://github.com/clong/DetectionLab.git /opt/DetectionLab
 # Install Vagrant
 mkdir /opt/vagrant
 cd /opt/vagrant || exit 1
-wget https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.deb
-dpkg -i vagrant_2.2.10_x86_64.deb
+wget https://releases.hashicorp.com/vagrant/2.2.14/vagrant_2.2.14_x86_64.deb
+dpkg -i vagrant_2.2.14_x86_64.deb
 
 # Disable IPv6 - may help with the vagrant-reload plugin: https://github.com/hashicorp/vagrant/issues/8795#issuecomment-468945063
 echo "net.ipv6.conf.all.disable_ipv6=1" >> /etc/sysctl.conf
@@ -40,8 +40,8 @@ sed -i 's/vb.gui = true/vb.gui = false/g' Vagrantfile
 # Install Packer
 mkdir /opt/packer
 cd /opt/packer || exit 1
-wget --progress=bar:force https://releases.hashicorp.com/packer/1.6.3/packer_1.6.3_linux_amd64.zip
-unzip packer_1.6.3_linux_amd64.zip
+wget --progress=bar:force https://releases.hashicorp.com/packer/1.6.6/packer_1.6.6_linux_amd64.zip
+unzip packer_1.6.6_linux_amd64.zip
 cp packer /usr/local/bin/packer
 
 # Make the Packer images headless

--- a/ci/manual_machine_bootstrap_vmware.sh
+++ b/ci/manual_machine_bootstrap_vmware.sh
@@ -28,8 +28,8 @@ git clone https://github.com/clong/DetectionLab.git /opt/DetectionLab
 # Install Vagrant
 mkdir /opt/vagrant
 cd /opt/vagrant || exit 1
-wget --progress=bar:force https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.deb
-dpkg -i vagrant_2.2.10_x86_64.deb
+wget --progress=bar:force https://releases.hashicorp.com/vagrant/2.2.14/vagrant_2.2.14_x86_64.deb
+dpkg -i vagrant_2.2.14_x86_64.deb
 # Disable IPv6 - may help with the vagrant-reload plugin: https://github.com/hashicorp/vagrant/issues/8795#issuecomment-468945063
 echo "net.ipv6.conf.all.disable_ipv6=1" >> /etc/sysctl.conf
 sysctl -p /etc/sysctl.conf > /dev/null
@@ -47,8 +47,8 @@ sed -i 's/v.gui = true/v.gui = false/g' Vagrantfile
 # Install Packer
 mkdir /opt/packer
 cd /opt/packer || exit 1
-wget --progress=bar:force https://releases.hashicorp.com/packer/1.6.3/packer_1.6.3_linux_amd64.zip
-unzip packer_1.6.3_linux_amd64.zip
+wget --progress=bar:force https://releases.hashicorp.com/packer/1.6.6/packer_1.6.6_linux_amd64.zip
+unzip packer_1.6.6_linux_amd64.zip
 cp packer /usr/local/bin/packer
 
 # Make the Packer images headless


### PR DESCRIPTION
- Set VMX settings not to sync time with the host clock (https://github.com/clong/DetectionLab/issues/573)
- Update Packer & Vagrant to current versions