### PR TITLE
HyperV: hyperv-create-nat-switch script refactor/adapter check updates

### DIFF
--- a/HyperV/hyperv-create-nat-switch.ps1
+++ b/HyperV/hyperv-create-nat-switch.ps1
@@ -1,32 +1,41 @@
 # See: https://www.petri.com/using-nat-virtual-switch-hyper-v
 
-If ("NATSwitch" -in (Get-VMSwitch | Select-Object -ExpandProperty Name) -eq $FALSE) {
-    'Creating Internal-only switch named "NATSwitch" on Windows Hyper-V host...'
+$NATHostIP = "192.168.38.1"
+$NATNetPrefixLength = 24
+$NATNet = "192.168.38.0/$NATNetPrefixLength"
+$NATNetName = "NATNetwork"
+$NATSwitchName = "NATSwitch"
+$NATSwitchNameAlias = "vEthernet ($NATSwitchName)"
 
-    New-VMSwitch -SwitchName "NATSwitch" -SwitchType Internal
+# Check our NAT switch exists, create it and configure it if it doesn't.
+If ("$NATSwitchName" -in (Get-VMSwitch | Select-Object -ExpandProperty Name) -eq $FALSE) {
+    "Creating Internal-only switch named ""$NatSwitchName"" on Windows Hyper-V host..."
 
-    New-NetIPAddress -IPAddress 192.168.38.1 -PrefixLength 24 -InterfaceAlias "vEthernet (NATSwitch)"
+    New-VMSwitch -SwitchName $NATSwitchName -SwitchType Internal
+    New-NetIPAddress -IPAddress $NATHostIP -PrefixLength $NATNetPrefixLength -InterfaceAlias $NATSwitchNameAlias
+    New-NetNAT -Name $NATNetName -InternalIPInterfaceAddressPrefix $NATNet
 
-    New-NetNAT -Name "NATNetwork" -InternalIPInterfaceAddressPrefix 192.168.38.0/24
-}
-else {
-    '"NATSwitch" for static IP configuration already exists; skipping'
-}
-
-If ("192.168.38.1" -in (Get-NetIPAddress | Select-Object -ExpandProperty IPAddress) -eq $FALSE) {
-    'Registering new IP address 192.168.38.1 on Windows Hyper-V host...'
-
-    New-NetIPAddress -IPAddress 192.168.38.1 -PrefixLength 24 -InterfaceAlias "vEthernet (NATSwitch)"
-}
-else {
-    '"192.168.38.1" for static IP configuration already registered; skipping'
+} else {
+    """$NATSwitchName"" VM Switch on Hyper-V host for guest static IP configuration already exists; skipping..."
 }
 
-If ("192.168.38.0/24" -in (Get-NetNAT | Select-Object -ExpandProperty InternalIPInterfaceAddressPrefix) -eq $FALSE) {
-    'Registering new NAT adapter for 192.168.38.0/24 on Windows Hyper-V host...'
+# Check that our Hyper-V host has the proper gateway address for the NAT Network.
+# TODO make sure that this is set for the proper NATSwitch
+If ("$NATHostIP" -in (Get-NetIPAddress | Select-Object -ExpandProperty IPAddress) -eq $FALSE) {
+    "Registering new IP address $NATHostIP on Windows Hyper-V host..."
 
-    New-NetNAT -Name "NATNetwork" -InternalIPInterfaceAddressPrefix 192.168.38.0/24
+    New-NetIPAddress -IPAddress $NATHostIP -PrefixLength $NATNetPrefixLength -InterfaceAlias $NATSwitchNameAlias
+
+} else {
+    """$NATHostIP"" Hyper-V host gateway address for guest static IP configuration already registered; skipping..."
 }
-else {
-    '"192.168.38.0/24" for static IP configuration already registered; skipping'
+
+# Check that our Hyper-V host has the proper NAT Network setup
+If ("$NATNet" -in (Get-NetNAT | Select-Object -ExpandProperty InternalIPInterfaceAddressPrefix) -eq $FALSE) {
+    "Registering new NAT adapter for $NATNet on Windows Hyper-V host..."
+
+    New-NetNAT -Name $NATNetName -InternalIPInterfaceAddressPrefix $NATNet
+
+} else {
+    """$NATNet"" Hyper-V host NAT Network for guest static IP configuration already registered; skipping"
 }

--- a/HyperV/hyperv-create-nat-switch.ps1
+++ b/HyperV/hyperv-create-nat-switch.ps1
@@ -20,8 +20,7 @@ If ("$NATSwitchName" -in (Get-VMSwitch | Select-Object -ExpandProperty Name) -eq
 }
 
 # Check that our Hyper-V host has the proper gateway address for the NAT Network.
-# TODO make sure that this is set for the proper NATSwitch
-If ("$NATHostIP" -in (Get-NetIPAddress | Select-Object -ExpandProperty IPAddress) -eq $FALSE) {
+If (@(Get-NetIPAddress | Where-Object {$_.IPAddress -eq "$NATHostIP" -and $_.InterfaceAlias -eq "$NATSwitchNameAlias"}).Count -eq 1) {
     "Registering new IP address $NATHostIP on Windows Hyper-V host..."
 
     New-NetIPAddress -IPAddress $NATHostIP -PrefixLength $NATNetPrefixLength -InterfaceAlias $NATSwitchNameAlias


### PR DESCRIPTION
## Background
One of the issues I ran into when using the HyperV provider was that I already had a network adapter set up on my box that was using the 192.168.38.0/24 network. This script had a check to create the NAT Network, and it also had a check to make sure that the 192.168.38.1 address was assigned to _a_ network adapter on the host. Unfortunately, this check was not robust enough to see that it was not associated with the expected network adapter. This led to strange issues where the vagrant build would work per guest/box until a reload was triggered and the NAT switch was swapped out. After that point, vagrant would be unable to reach the guest it spun up (because the NAT switch it was trying to use was just getting an APIPA/link-local auto-assigned address, since the address/network it _wanted_ was already taken). It was particularly confusing since the script was saying that the static address was assigned (properly)... Eventually, I found out that the static address it was referring to was my host machine, not the guest, and that it _was_ in fact assigned... just not to the adapter I wanted it to be (one I had setup for virtualbox, so it was _just_ an adapter; i.e. not visible via the `Get-NetNAT` or `Get-VMSwitch`, which is why those checks are fine and unchanged here).

## What am I changing
In this PR, I...
* Refactor some of the code to use variables rather than hard coding everything.
* Update some of the "else" clause/skipping messages to be more clear as to why the skip was occurring
* Update the logic on the second if statement to not only check if the expected static gateway IP is set on the host on some adapter, but check that the expected static gateway IP is set on the host on the _expected_ adapter (based on the InterfaceAlias property it "should" be created with)

This change should be low risk, most of the change is cosmetic.

Thanks in advance! Love the project!