### PR TITLE
fix a typo in vm_name field in qemu type section of windows_2016.json

### DIFF
--- a/Packer/windows_2016.json
+++ b/Packer/windows_2016.json
@@ -83,7 +83,7 @@
     },
     {
       "type": "qemu",
-      "vm_name": "windows_10",
+      "vm_name": "WindowsServer2016",
       "communicator": "winrm",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum`}}",


### PR DESCRIPTION
While I was running packer in QEMU environment I discovered a typo in the windows_2016.json. It caused me some confusion while I was debugging windows 2016 build (thought I had run packer on wrong file). Minor inconvenience and a small pull request, but here it is.