### PR TITLE
Add Custom props.conf for Zeek Splunk TA

### DIFF
--- a/Vagrant/logger_bootstrap.sh
+++ b/Vagrant/logger_bootstrap.sh
@@ -195,6 +195,10 @@ install_splunk() {
     cp /vagrant/resources/splunk_server/windows_ta_props.conf /opt/splunk/etc/apps/Splunk_TA_windows/default/props.conf
     cp /vagrant/resources/splunk_server/sysmon_ta_props.conf /opt/splunk/etc/apps/TA-microsoft-sysmon/default/props.conf
 
+    # Add props.conf to Splunk Zeek TA to properly parse timestamp
+    # and avoid grouping events as a single event
+    cp /vagrant/resources/splunk_server/zeek_ta_props.conf /opt/splunk/etc/apps/Splunk_TA_bro/local/props.conf
+
     # Add custom Macro definitions for ThreatHunting App
     cp /vagrant/resources/splunk_server/macros.conf /opt/splunk/etc/apps/ThreatHunting/default/macros.conf
     # Fix props.conf in ThreatHunting App

--- a/Vagrant/resources/splunk_server/zeek_ta_props.conf
+++ b/Vagrant/resources/splunk_server/zeek_ta_props.conf
@@ -1,0 +1,12 @@
+[zeek:json]
+DATETIME_CONFIG =
+INDEXED_EXTRACTIONS = json
+KV_MODE = none
+LINE_BREAKER = ([\r\n]+)
+NO_BINARY_CHECK = true
+category = Structured
+description = Zeek JSON sourcetype with fixed timestamp parsing.
+disabled = false
+pulldown_type = true
+TIMESTAMP_FIELDS = ts
+TIME_FORMAT = %s.%6N


### PR DESCRIPTION
I've ran into this same issue in the past with this Splunkbase app where Zeek log/events are not properly separated and are often grouped together as a single entry.

Here's an example of the behavior:
![image](https://user-images.githubusercontent.com/20070360/107111676-83d14a80-6817-11eb-9da3-8e1002a2d47e.png)

This PR introduces a custom props.conf that fixes this so each entry is properly separated and contains valid timestamps. They'll then be properly parsed as JSON and make searching much more enjoyable. :)
![image](https://user-images.githubusercontent.com/20070360/107111707-b0856200-6817-11eb-8fff-3c6f4d26b98d.png)

Let me know if there's more I need to do in this PR. I added in the custom props.conf and then updated the logger_bootstrap.sh script to copy it into the TA's configuration.
