### PR TITLE
Fix Fleet install in ESXi to use the latest fleet.zip release

### DIFF
--- a/ESXi/ansible/roles/logger/tasks/main.yml
+++ b/ESXi/ansible/roles/logger/tasks/main.yml
@@ -300,7 +300,7 @@
     executable: /bin/bash
   become: yes
   shell: |
-    if [ -f "/opt/fleet" ]; then
+    if [ -d "/opt/fleet" ]; then
       echo "[$(date +%H:%M:%S)]: Fleet is already installed"
     else
       cd /opt || exit 1
@@ -314,7 +314,7 @@
       mysql -uroot -pkolide -e "create database kolide;"
 
       # Always download the latest release of Fleet
-      curl -s https://api.github.com/repos/fleetdm/fleet/releases/latest | grep 'https://github.com' | grep "/fleet.zip" | cut -d ':' -f 2,3 | tr -d '"' | wget --progress=bar:force -i -
+      curl -s https://api.github.com/repos/fleetdm/fleet/releases | grep 'https://github.com' | grep "/fleet.zip" | cut -d ':' -f 2,3 | tr -d '"' | tr -d ' '  | head -1 | wget --progress=bar:force -i -
       unzip fleet.zip -d fleet
       cp fleet/linux/fleetctl /usr/local/bin/fleetctl && chmod +x /usr/local/bin/fleetctl
       cp fleet/linux/fleet /usr/local/bin/fleet && chmod +x /usr/local/bin/fleet


### PR DESCRIPTION
FleetDM's releases do not always contain a fleet.zip ([example](https://github.com/fleetdm/fleet/releases/tag/3.7.4)). To handle these cases, we need to parse all the releases to find the latest one with a fleet.zip file. This PR brings the ESXi code line in line with the Vagrant code line: https://github.com/clong/DetectionLab/commit/eedd621537c1b4f617e44da2e5f51d6da72b0923.

I've also adjusted the script to use `-d` instead of `-f` because `/opt/fleet` should be a directory. This check seemed to fail on my deployment during a re-run when Fleet was already installed. 