### PR TITLE
add netplan stanza for eth1 to configure dhcp

### DIFF
--- a/ESXi/Packer/scripts/networking.sh
+++ b/ESXi/Packer/scripts/networking.sh
@@ -11,6 +11,8 @@ network:
   ethernets:
     eth0:
       dhcp4: true
+    eth1:
+      dhcp4: true
 EOF
 else
   # Adding a 2 sec delay to the interface up, to make the dhclient happy


### PR DESCRIPTION
The ubuntu1804 host was not bringing eth1 up, due to a missing stanza in netplan.io. Netplan was introduced in 1804