### PR TITLE
Fix Packer - QEMU doesn't boot to ISO image.

### DIFF
--- a/Packer/windows_10.json
+++ b/Packer/windows_10.json
@@ -120,6 +120,10 @@
         [
           "-drive",
           "file={{ user `packer_build_dir`}}/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-drive",
+          "file={{ user `iso_url` }},media=cdrom,index=2"
         ]
       ],
       "floppy_files": [

--- a/Packer/windows_2016.json
+++ b/Packer/windows_2016.json
@@ -114,6 +114,10 @@
         [
           "-drive",
           "file={{ user `packer_build_dir`}}/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-drive",
+          "file={{ user `iso_url` }},media=cdrom,index=2"
         ]
       ],
       "floppy_files": [


### PR DESCRIPTION
Hello,
When I build windows boxes with Qemu in the new version of Packer, an error happened. Therefore, it failed to build.
According to this [issue](https://github.com/StefanScherer/packer-windows/issues/280) and my tries, the reason is that the new version of Packer overrides "qemuargs", so QEMU doesn't boot to ISO image.

I have solved this bug and build it successfully by modifying the config. 
Please check my PR. Thank you.