### PR TITLE
Elevate to TrustedInstaller to disable Defender on Windows 10

### DIFF
--- a/Vagrant/scripts/Invoke-CommandAs.ps1
+++ b/Vagrant/scripts/Invoke-CommandAs.ps1
@@ -1,0 +1,34 @@
+# Based on research by James Forshaw (@tiraniddo)
+# https://www.tiraniddo.dev/2019/09/the-art-of-becoming-trustedinstaller.html
+
+function Invoke-CommandAs {
+    param (
+        [Parameter(Position=0)][String]$User,
+        [Parameter(Position=1)][ScriptBlock]$ScriptBlock
+    )
+
+    $LogFile = New-TemporaryFile
+    $ScriptFile = New-TemporaryFile
+
+    "Invoke-Command { $ScriptBlock } *> $LogFile" | Out-File $ScriptFile
+    $ScriptFile = Rename-Item $ScriptFile "$($ScriptFile.BaseName).ps1" -PassThru
+
+    $TaskName = 'Invoke-CommandAs Task'
+    $TaskAction = New-ScheduledTaskAction `
+        -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -File $ScriptFile"
+    Register-ScheduledTask -TaskName $TaskName -Action $TaskAction -Force | Out-Null
+
+    ($ScheduleService = New-Object -ComObject Schedule.Service).Connect()
+    $ScheduleService.GetFolder('\').GetTask($TaskName).RunEx($null, 0, 0, $User) | Out-Null
+
+    while ((Get-ScheduledTask $TaskName).State -eq 'Running') { Start-Sleep 0.5 }
+
+    if (($Result = (Get-ScheduledTaskInfo $TaskName).LastTaskResult) -ne 0) {
+        throw "The scheduled task '$TaskName' failed with result code $Result."
+    }
+
+    Unregister-ScheduledTask $TaskName -Confirm:$false
+    Get-Content $LogFile
+    Remove-Item $LogFile, $ScriptFile
+}

--- a/Vagrant/scripts/install-redteam.ps1
+++ b/Vagrant/scripts/install-redteam.ps1
@@ -13,7 +13,12 @@ If ($hostname -eq "win10") {
   # Adding Defender exclusions just in case
   Set-MpPreference -ExclusionPath "C:\Tools"
   Add-MpPreference -ExclusionPath "C:\Users\vagrant\AppData\Local\Temp"
-  Set-MpPreference -DisableRealtimeMonitoring $true
+
+  . c:\vagrant\scripts\Invoke-CommandAs.ps1
+  Invoke-CommandAs 'NT SERVICE\TrustedInstaller' {
+    Set-Service WinDefend -StartupType Disabled
+    Stop-Service WinDefend
+  }
 }
 
 # Windows Defender should be disabled by the GPO or uninstalled already, but we'll keep this just in case


### PR DESCRIPTION
Fix #648