### PR TITLE
Replace deprecated map() with tomap() AWS terraform

### DIFF
--- a/AWS/Terraform/main.tf
+++ b/AWS/Terraform/main.tf
@@ -172,8 +172,10 @@ resource "aws_instance" "logger" {
   instance_type = "t3.medium"
   ami           = coalesce(var.logger_ami, data.aws_ami.logger_ami.image_id)
 
-  tags = merge(var.custom-tags, map(
-    "Name", "${var.instance_name_prefix}logger"
+  tags = merge(var.custom-tags, tomap(
+    {
+      "Name" = "${var.instance_name_prefix}logger"
+    }
   ))
 
   subnet_id              = aws_subnet.default.id
@@ -237,8 +239,10 @@ resource "aws_instance" "dc" {
   # Uses the local variable if external data source resolution fails
   ami = coalesce(var.dc_ami, data.aws_ami.dc_ami.image_id)
 
-  tags = merge(var.custom-tags, map(
-    "Name", "${var.instance_name_prefix}dc.windomain.local"
+  tags = merge(var.custom-tags, tomap(
+    {
+      "Name" = "${var.instance_name_prefix}dc.windomain.local"
+    }
   ))
 
   subnet_id              = aws_subnet.default.id
@@ -272,8 +276,10 @@ resource "aws_instance" "wef" {
   # Uses the local variable if external data source resolution fails
   ami = coalesce(var.wef_ami, data.aws_ami.wef_ami.image_id)
 
-  tags = merge(var.custom-tags, map(
-    "Name", "${var.instance_name_prefix}wef.windomain.local"
+  tags = merge(var.custom-tags, tomap(
+    {
+      "Name" = "${var.instance_name_prefix}wef.windomain.local"
+    }
   ))
 
   subnet_id              = aws_subnet.default.id
@@ -309,8 +315,10 @@ resource "aws_instance" "wef" {
 #   # Uses the local variable if external data source resolution fails
 #   ami = coalesce(var.exchange_ami, data.aws_ami.exchange_ami.image_id)
 
-#   tags = merge(var.custom-tags, map(
-#     "Name", "${var.instance_name_prefix}exchange.windomain.local"
+#   tags = merge(var.custom-tags, tomap(
+#     {
+#       "Name" = "${var.instance_name_prefix}exchange.windomain.local"
+#     }
 #   ))
 
 #   subnet_id              = aws_subnet.default.id
@@ -344,8 +352,10 @@ resource "aws_instance" "win10" {
   # Uses the local variable if external data source resolution fails
   ami = coalesce(var.win10_ami, data.aws_ami.win10_ami.image_id)
 
-  tags = merge(var.custom-tags, map(
-    "Name", "${var.instance_name_prefix}win10.windomain.local"
+  tags = merge(var.custom-tags, tomap(
+    {
+      "Name" = "${var.instance_name_prefix}win10.windomain.local"
+    }
   ))
 
   subnet_id              = aws_subnet.default.id


### PR DESCRIPTION
Solves the following error while trying to execute with the latest Terraform:

![image](https://user-images.githubusercontent.com/26856693/117592760-37e0bb00-b110-11eb-85a7-42064707976b.png)
