### PR TITLE
Replace non-existent 7z1900-x64.msi file with 7z2102-x64.msi URL

### DIFF
--- a/Packer/scripts/compact.bat
+++ b/Packer/scripts/compact.bat
@@ -1,7 +1,7 @@
-if not exist "C:\Windows\Temp\7z1900-x64.msi" (
-  powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')" <NUL
+if not exist "C:\Windows\Temp\7z2102-x64.msi" (
+  powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z2102-x64.msi', 'C:\Windows\Temp\7z2102-x64.msi')" <NUL
 )
-msiexec /qb /i C:\Windows\Temp\7z1900-x64.msi
+msiexec /qb /i C:\Windows\Temp\7z2102-x64.msi
 
 if not exist "C:\Windows\Temp\SDelete.zip" (
   powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://download.sysinternals.com/files/SDelete.zip', 'C:\Windows\Temp\SDelete.zip')" <NUL
@@ -12,7 +12,7 @@ if not exist "C:\Windows\Temp\sdelete.exe" (
   cmd /c ""C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\SDelete.zip -oC:\Windows\Temp"
 )
 
-msiexec /qb /x C:\Windows\Temp\7z1900-x64.msi
+msiexec /qb /x C:\Windows\Temp\7z2102-x64.msi
 
 net stop wuauserv 1> nul 2>&1
 rmdir /S /Q C:\Windows\SoftwareDistribution\Download

--- a/Packer/scripts/vm-guest-tools.bat
+++ b/Packer/scripts/vm-guest-tools.bat
@@ -1,10 +1,10 @@
-if not exist "C:\Windows\Temp\7z1900-x64.msi" (
-  powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')" <NUL
+if not exist "C:\Windows\Temp\7z2102-x64.msi" (
+  powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z2102-x64.msi', 'C:\Windows\Temp\7z2102-x64.msi')" <NUL
 )
-if not exist "C:\Windows\Temp\7z1900-x64.msi" (
-  powershell -Command "Start-Sleep 5; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')" <NUL
+if not exist "C:\Windows\Temp\7z2102-x64.msi" (
+  powershell -Command "Start-Sleep 5; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z2102-x64.msi', 'C:\Windows\Temp\7z2102-x64.msi')" <NUL
 )
-msiexec /qb /i C:\Windows\Temp\7z1900-x64.msi
+msiexec /qb /i C:\Windows\Temp\7z2102-x64.msi
 
 if "%PACKER_BUILDER_TYPE%" equ "vmware-iso" goto :vmware
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox-iso" goto :virtualbox
@@ -48,4 +48,4 @@ rd /S /Q "C:\Windows\Temp\virtualbox"
 goto :done
 
 :done
-msiexec /qb /x C:\Windows\Temp\7z1900-x64.msi
+msiexec /qb /x C:\Windows\Temp\7z2102-x64.msi

--- a/Packer/scripts/vm-guest-tools.ps1
+++ b/Packer/scripts/vm-guest-tools.ps1
@@ -1,10 +1,10 @@
-if (!( Test-Path "C:\Windows\Temp\7z1900-x64.msi")) {
-  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')
+if (!( Test-Path "C:\Windows\Temp\7z2102-x64.msi")) {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z2102-x64.msi', 'C:\Windows\Temp\7z2102-x64.msi')
 }
-if (!(Test-Path "C:\Windows\Temp\7z1900-x64.msi")) {
-  Start-Sleep 5; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')
+if (!(Test-Path "C:\Windows\Temp\7z2102-x64.msi")) {
+  Start-Sleep 5; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z2102-x64.msi', 'C:\Windows\Temp\7z2102-x64.msi')
 }
-cmd /c msiexec /qb /i C:\Windows\Temp\7z1900-x64.msi
+cmd /c msiexec /qb /i C:\Windows\Temp\7z2102-x64.msi
 
 if ("$env:PACKER_BUILDER_TYPE" -eq "vmware-iso") {
 
@@ -85,4 +85,4 @@ if ("$env:PACKER_BUILDER_TYPE" -eq "virtualbox-iso") {
     cmd /c rd /S /Q "C:\Windows\Temp\virtualbox"
 }
 
-cmd /c msiexec /qb /x C:\Windows\Temp\7z1900-x64.msi
+cmd /c msiexec /qb /x C:\Windows\Temp\7z2102-x64.msi


### PR DESCRIPTION
Packer is currently not able to install 7-zip which causes several error's.
Reason: The 7-zip msi URL https://www.7-zip.org/a/7z1900-x64.msi is currently not available. As an alternative the v21.02 msi file can be downloaded from 7-zip.org.