### PR TITLE
Update main.tf

### DIFF
--- a/AWS/Terraform/modules/exchange/main.tf
+++ b/AWS/Terraform/modules/exchange/main.tf
@@ -26,8 +26,8 @@ resource "aws_instance" "exchange" {
   # Uses the local variable if external data source resolution fails
   ami = coalesce(var.exchange_ami, data.aws_ami.exchange_ami.image_id)
 
-  tags = merge(var.custom-tags, map(
-    "Name", "${var.instance_name_prefix}exchange.windomain.local"
+  tags = merge(var.custom-tags, tomap(
+    {"Name" = "${var.instance_name_prefix}exchange.windomain.local"}
   ))
 
   subnet_id              = var.subnet_id


### PR DESCRIPTION
map() is a deprecated function. Changed map() to tomap() with the proper syntax.