### PR TITLE
AWS/Terraform: allow non-default variables for Exchange configuration

### DIFF
--- a/AWS/Terraform/exchange.tf
+++ b/AWS/Terraform/exchange.tf
@@ -3,6 +3,8 @@
 module "exchange" {
   source = "./modules/exchange"
   region = var.region
+  profile                 = var.profile
+  shared_credentials_file = var.shared_credentials_file
   subnet_id = aws_subnet.default.id
   security_group_id = [aws_security_group.windows.id]
   instance_name_prefix = var.instance_name_prefix

--- a/AWS/Terraform/exchange.tf
+++ b/AWS/Terraform/exchange.tf
@@ -1,15 +1,14 @@
 ## Remove the block comment to enable the creation of the Exchange server
 /*
 module "exchange" {
-  source = "./modules/exchange"
-  region = var.region
+  source                  = "./modules/exchange"
+  region                  = var.region
   profile                 = var.profile
   shared_credentials_file = var.shared_credentials_file
-  subnet_id = aws_subnet.default.id
-  security_group_id = [aws_security_group.windows.id]
-  instance_name_prefix = var.instance_name_prefix
-  custom-tags = var.custom-tags
-  exchange_ami = var.exchange_ami
+  subnet_id               = aws_subnet.default.id
+  security_group_id       = [aws_security_group.windows.id]
+  instance_name_prefix    = var.instance_name_prefix
+  custom-tags             = var.custom-tags
+  exchange_ami            = var.exchange_ami
 }
 */
-

--- a/AWS/Terraform/modules/exchange/locals.tf
+++ b/AWS/Terraform/modules/exchange/locals.tf
@@ -1,3 +1,3 @@
-locals {  
-  exchange_url    = "https://${aws_instance.exchange.public_ip}"
+locals {
+  exchange_url = "https://${aws_instance.exchange.public_ip}"
 }

--- a/AWS/Terraform/modules/exchange/main.tf
+++ b/AWS/Terraform/modules/exchange/main.tf
@@ -1,6 +1,8 @@
 # Shouldnt need this but alas: https://github.com/hashicorp/terraform-provider-aws/issues/14917
 provider "aws" {
   region = var.region
+  profile = var.profile
+  shared_credentials_file = var.shared_credentials_file
 }
 
 resource "aws_instance" "exchange" {

--- a/AWS/Terraform/modules/exchange/main.tf
+++ b/AWS/Terraform/modules/exchange/main.tf
@@ -1,7 +1,7 @@
 # Shouldnt need this but alas: https://github.com/hashicorp/terraform-provider-aws/issues/14917
 provider "aws" {
-  region = var.region
-  profile = var.profile
+  region                  = var.region
+  profile                 = var.profile
   shared_credentials_file = var.shared_credentials_file
 }
 
@@ -15,7 +15,7 @@ resource "aws_instance" "exchange" {
       "powershell.exe -c \"Add-Content 'c:\\windows\\system32\\drivers\\etc\\hosts' '        192.168.38.103    wef.windomain.local'\"",
       "powershell.exe -c \"Add-Content 'c:\\windows\\system32\\drivers\\etc\\hosts' '        192.168.38.102    dc.windomain.local'\"",
       "powershell.exe -c \"Add-Content 'c:\\windows\\system32\\drivers\\etc\\hosts' '        192.168.38.102    windomain.local'\"",
-      ]
+    ]
 
     connection {
       type     = "winrm"
@@ -29,7 +29,7 @@ resource "aws_instance" "exchange" {
   ami = coalesce(var.exchange_ami, data.aws_ami.exchange_ami.image_id)
 
   tags = merge(var.custom-tags, tomap(
-    {"Name" = "${var.instance_name_prefix}exchange.windomain.local"}
+    { "Name" = "${var.instance_name_prefix}exchange.windomain.local" }
   ))
 
   subnet_id              = var.subnet_id

--- a/AWS/Terraform/modules/exchange/variables.tf
+++ b/AWS/Terraform/modules/exchange/variables.tf
@@ -26,9 +26,9 @@ variable "shared_credentials_file" {
 }
 
 variable "custom-tags" {
-  type = map(string)
+  type        = map(string)
   description = "Optional mapping for additional tags to apply to all related AWS resources"
-  default = {}
+  default     = {}
 }
 
 variable "exchange_ami" {

--- a/AWS/Terraform/modules/exchange/variables.tf
+++ b/AWS/Terraform/modules/exchange/variables.tf
@@ -15,6 +15,16 @@ variable "region" {
   default = ""
 }
 
+variable "profile" {
+  type    = string
+  default = ""
+}
+
+variable "shared_credentials_file" {
+  type    = string
+  default = ""
+}
+
 variable "custom-tags" {
   type = map(string)
   description = "Optional mapping for additional tags to apply to all related AWS resources"


### PR DESCRIPTION
Preamble - I'm running the following configuration:
```
Terraform v1.0.3
on linux_amd64
+ provider registry.terraform.io/hashicorp/aws v3.52.0
```

When using custom values for the following Terraform variables (defined in the root [variables.tf](https://github.com/clong/DetectionLab/blob/master/AWS/Terraform/variables.tf) file):
* `region`
* `profile`
* `shared_credentials_file`

Terraform threw errors like the so:

```
modules/exchange/provider.aws: error validating provider credentials: <garbage> no valid providers in chain <garbage>
```

I was able to fix this behavior by making the following changes:
1. Declaring and adding the `profile` and `shared_credentials_file` variables to the Terraform files under `modules\exchange` 
1. Updating the root `exchange.tf` file to grab values defined in the root `.tfvars` file

I'm in no way an advanced Terraform user so I don't know if it's the optimal way, but I could successfully build the Exchange-enabled lab within my AWS environment after these modifications.