### PR TITLE
Update ubuntu1804_esxi.json

### DIFF
--- a/ESXi/Packer/ubuntu1804_esxi.json
+++ b/ESXi/Packer/ubuntu1804_esxi.json
@@ -105,7 +105,7 @@
         "iso_name": "ubuntu-18.04.5-server-amd64.iso",
         "memory": "4096",
         "mirror": "http://cdimage.ubuntu.com",
-        "mirror_directory": "ubuntu/releases/18.04.4/release",
+        "mirror_directory": "ubuntu/releases/18.04.5/release",
         "name": "ubuntu-18.04",
         "no_proxy": "{{env `no_proxy`}}",
         "preseed_path": "preseed.cfg",


### PR DESCRIPTION
Update Ubuntu iso image URL to 18.04.5, previous URL returns a 404 when attempting to fetch the Ubuntu ISO.