### PR TITLE
Fix for chmod in guacamole

### DIFF
--- a/Vagrant/logger_bootstrap.sh
+++ b/Vagrant/logger_bootstrap.sh
@@ -572,7 +572,7 @@ install_guacamole() {
   wget --progress=bar:force "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/1.0.0/binary/guacamole-1.0.0.war" -O guacamole.war
   mkdir /etc/guacamole
   mkdir /etc/guacamole/shares
-  sudo chmod 777 mkdir /etc/guacamole/shares
+  sudo chmod 777 /etc/guacamole/shares
   mkdir /usr/share/tomcat8/.guacamole
   cp /vagrant/resources/guacamole/user-mapping.xml /etc/guacamole/
   cp /vagrant/resources/guacamole/guacamole.properties /etc/guacamole/


### PR DESCRIPTION
Happen to see an error while provisioning the logger:

`chmod: cannot access 'mkdir': No such file or directory`

Tracked it back to this line, looks like a greedy copy and paste grabbed the entire command of the line previous instead of just the file path :)