### PR TITLE
Fix for SetMpPreference failing if Defender is Disabled

### DIFF
--- a/Vagrant/scripts/install-redteam.ps1
+++ b/Vagrant/scripts/install-redteam.ps1
@@ -9,7 +9,7 @@ $ProgressPreference = 'SilentlyContinue'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 # Windows Defender should be disabled already by O&O ShutUp10 and the GPO
-If ($hostname -eq "win10") {
+If ($hostname -eq "win10" -And (Get-ServiceDetail -Name WinDefend).StartMode -ne 'Disabled' ) {
   # Adding Defender exclusions just in case
   Set-MpPreference -ExclusionPath "C:\Tools"
   Add-MpPreference -ExclusionPath "C:\Users\vagrant\AppData\Local\Temp"


### PR DESCRIPTION
If you need to rerun provisioning on the Win10 box, and Defender has been disabled in a prior run, the calls to Set-MpPreference and Add-MpPreference will fail with a NativeCommandError and prevent the script from succeeding.  This commit adds some idempotency via a check to see if the service is already disabled before running these commands.