### PR TITLE
Proxmox: add user defined variables for storage_pool and type

### DIFF
--- a/Proxmox/Packer/ubuntu2004_proxmox.json
+++ b/Proxmox/Packer/ubuntu2004_proxmox.json
@@ -23,7 +23,7 @@
           {
             "type": "scsi",
             "disk_size": "64G",
-            "storage_pool": "local-lvm",
+            "storage_pool": "{{ user `proxmox_storage_pool` }}",
             "storage_pool_type": "lvm-thin",
             "cache_mode": "writeback",
             "format": "raw"

--- a/Proxmox/Packer/ubuntu2004_proxmox.json
+++ b/Proxmox/Packer/ubuntu2004_proxmox.json
@@ -24,7 +24,7 @@
             "type": "scsi",
             "disk_size": "64G",
             "storage_pool": "{{ user `proxmox_storage_pool` }}",
-            "storage_pool_type": "lvm-thin",
+            "storage_pool_type": "{{ user `proxmox_storage_pool_type` }}",
             "cache_mode": "writeback",
             "format": "raw"
           }

--- a/Proxmox/Packer/variables.json
+++ b/Proxmox/Packer/variables.json
@@ -5,5 +5,6 @@
 	"proxmox_password": "",
 	"proxmox_network_with_dhcp_and_internet": "vmbr0",
 	"proxmox_storage_pool": "local-lvm",
+	"proxmox_storage_pool_type": "lvm-thin",
 	"provisioning_machine_ip": ""
 }

--- a/Proxmox/Packer/variables.json
+++ b/Proxmox/Packer/variables.json
@@ -4,5 +4,6 @@
 	"proxmox_username": "root@pam",
 	"proxmox_password": "",
 	"proxmox_network_with_dhcp_and_internet": "vmbr0",
+	"proxmox_storage_pool": "local-lvm",
 	"provisioning_machine_ip": ""
 }

--- a/Proxmox/Packer/windows_10_proxmox.json
+++ b/Proxmox/Packer/windows_10_proxmox.json
@@ -23,7 +23,7 @@
           {
             "type": "scsi",
             "disk_size": "64G",
-            "storage_pool": "local-lvm",
+            "storage_pool": "{{ user `proxmox_storage_pool` }}",
             "storage_pool_type": "lvm-thin",
             "cache_mode": "writeback",
             "format": "raw"

--- a/Proxmox/Packer/windows_10_proxmox.json
+++ b/Proxmox/Packer/windows_10_proxmox.json
@@ -24,7 +24,7 @@
             "type": "scsi",
             "disk_size": "64G",
             "storage_pool": "{{ user `proxmox_storage_pool` }}",
-            "storage_pool_type": "lvm-thin",
+            "storage_pool_type": "{{ user `proxmox_storage_pool_type` }}",
             "cache_mode": "writeback",
             "format": "raw"
           }

--- a/Proxmox/Packer/windows_2016_proxmox.json
+++ b/Proxmox/Packer/windows_2016_proxmox.json
@@ -23,7 +23,7 @@
           {
             "type": "scsi",
             "disk_size": "64G",
-            "storage_pool": "local-lvm",
+            "storage_pool": "{{ user `proxmox_storage_pool` }}",
             "storage_pool_type": "lvm-thin",
             "cache_mode": "writeback",
             "format": "raw"

--- a/Proxmox/Packer/windows_2016_proxmox.json
+++ b/Proxmox/Packer/windows_2016_proxmox.json
@@ -24,7 +24,7 @@
             "type": "scsi",
             "disk_size": "64G",
             "storage_pool": "{{ user `proxmox_storage_pool` }}",
-            "storage_pool_type": "lvm-thin",
+            "storage_pool_type": "{{ user `proxmox_storage_pool_type` }}",
             "cache_mode": "writeback",
             "format": "raw"
           }


### PR DESCRIPTION
Allowing a user to target their desired storage_pool in `variables.json` when executing the deployment. https://detectionlab.network/deployment/proxmox/