### PR TITLE
Handle multiple links in latest Velociraptor release

### DIFF
--- a/Vagrant/scripts/install-velociraptor.ps1
+++ b/Vagrant/scripts/install-velociraptor.ps1
@@ -15,7 +15,7 @@ Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Determining latest release of Velocir
 # Disabling the progress bar speeds up IWR https://github.com/PowerShell/PowerShell/issues/2138
 $ProgressPreference = 'SilentlyContinue'
 $tag = (Invoke-WebRequest "https://api.github.com/repos/Velocidex/velociraptor/releases" -UseBasicParsing | ConvertFrom-Json)[0].tag_name
-$velociraptorDownloadUrl = "https://github.com" + ((Invoke-WebRequest "https://github.com/Velocidex/velociraptor/releases/latest" -UseBasicParsing).links | Select-Object -ExpandProperty href | Select-String "windows-amd64.msi$")
+$velociraptorDownloadUrl = "https://github.com" + ((Invoke-WebRequest "https://github.com/Velocidex/velociraptor/releases/latest" -UseBasicParsing).links | Select-Object -ExpandProperty href | Select-String "windows-amd64.msi$" | Select-Object -First 1)
 $velociraptorMSIPath = 'C:\Users\vagrant\AppData\Local\Temp\velociraptor.msi'
 $velociraptorLogFile = 'c:\Users\vagrant\AppData\Local\Temp\velociraptor_install.log'
 If (-not (Test-Path $velociraptorLogFile)) {


### PR DESCRIPTION
This commit fixes a situation where Vagrant installation script tries to look up Github download URL for the latest version of Velociraptor and finds more than 1 URL.

Right now Velociraptor has been released in version 0.6.2, however a patch 0.6.2-1 is also available, both [here](https://github.com/Velocidex/velociraptor/releases/tag/v0.6.2) at the same release URL. Provisioning of DC machine fails and can't self-repair with subsequent provisioning attempts. The script returns the following string as a URL for download.:

    https://github.com/Velocidex/velociraptor/releases/download/v0.6.2/velociraptor-v0.6.2-1-windows-amd64.msi /Velocidex/velociraptor/releases/download/v0.6.2/velociraptor-v0.6.2-windows-amd64.msi

The fix just takes the first URL returned. Since it goes from the top to bottom it will most likely be the latest patch version. 