### PR TITLE
BOTS installation script fixes

### DIFF
--- a/Vagrant/scripts/install-botsv2.sh
+++ b/Vagrant/scripts/install-botsv2.sh
@@ -45,3 +45,4 @@ tar zxvf /opt/botsv2_data_set_attack_only.tgz -C /opt/splunk/etc/apps/
 ## FULL DATASET COMMENT BLOCK ENDS ###
 
 echo "BOTSv2 Installation complete!"
+## line ending bug fixes

--- a/Vagrant/scripts/install-botsv3.sh
+++ b/Vagrant/scripts/install-botsv3.sh
@@ -52,3 +52,4 @@ echo "[$(date +%H:%M:%S)]: Restarting Splunk..."
 /opt/splunk/bin/splunk restart
 
 echo "BOTSv3 Installation complete!"
+# line ending fixes


### PR DESCRIPTION
commit looks like nothing is changed. However, these scripts utilize Windows CR LF line endings that cause errors:

![image](https://user-images.githubusercontent.com/11021725/147952938-f265a807-1427-4284-8334-5fe56f41f874.png)
