### PR TITLE
Terraform: require azurerm >= 2.93.0

### DIFF
--- a/Azure/Terraform/modules/exchange/main.tf
+++ b/Azure/Terraform/modules/exchange/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 provider "azurerm" {
-  version = "=2.12.0"
+  version = ">=2.93.0"
   features {}
 }
 

--- a/Azure/Terraform/versions.tf
+++ b/Azure/Terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     azurerm = {
-      version = "=2.12.0"
+      version = ">=2.93.0"
     }
   }
 }


### PR DESCRIPTION
On my development machine (Ubuntu Focal), the `terraform apply` step fails due to an authentication error: "Error populating Client ID from the Azure CLI: No Authorization Tokens were found - please ensure the Azure CLI is installed and then log-in with az login". Given that I was able to retrieve the access token via the Azure CLI, the error must have been caused by a bug in the `azurerm` provider.

According to https://github.com/Azure/azure-cli/issues/20356, upgrading to the latest `azurerm` provider should resolve the bug. 2.12.0 dates back to May 2020; in the era of cloud technology, 2.12.0 seems obsolete. Upgrading to any version matching the constraint `>= 2.93.0` (2.93.0 was released in January 2022) - with the help of `terraform init -upgrade` - has fixed the issue for me.

Disclaimer: this patch was only tested against the 'main virtual machines', not the 'Exchange' one.