### PR TITLE
Fix velociraptor download

### DIFF
--- a/Vagrant/scripts/install-velociraptor.ps1
+++ b/Vagrant/scripts/install-velociraptor.ps1
@@ -18,7 +18,10 @@ Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Determining latest release of Velocir
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 # Disabling the progress bar speeds up IWR https://github.com/PowerShell/PowerShell/issues/2138
 $ProgressPreference = 'SilentlyContinue'
-$velociraptorDownloadUrl = "https://github.com" + ((Invoke-WebRequest "https://github.com/Velocidex/velociraptor/releases" -UseBasicParsing).links | Select-Object -ExpandProperty href | Select-String "windows-amd64.msi$" | Select-Object -First 1)
+# Fix issue #869: Problem is that link to windows msi is hidden behind toogle item and not accesible, therefore get link for linux and replace with windows link
+$velociraptorDownloadUrlLinux = "https://github.com" + ((Invoke-WebRequest "https://github.com/Velocidex/velociraptor/releases" -UseBasicParsing).links | Select-Object -ExpandProperty href | Select-String "linux-amd64$" | Select-Object -First 1)
+$velociraptorDownloadUrl = $velociraptorDownloadUrlLinux.replace("linux-amd64", "windows-amd64.msi")
+Write-Host "Downloading Velociraptor from $velociraptorDownloadUrl"
 $velociraptorMSIPath = 'C:\Users\vagrant\AppData\Local\Temp\velociraptor.msi'
 $velociraptorLogFile = 'c:\Users\vagrant\AppData\Local\Temp\velociraptor_install.log'
 If (-not(Test-Path $velociraptorLogFile) -or ($Update -eq $true)) {


### PR DESCRIPTION
Closes #869

Problem is that link to windows msi is hidden behind toogle item and not accesible, therefore get link for linux and replace with windows link