### PR TITLE
Copy velociraptor config to default location

### DIFF
--- a/Vagrant/scripts/install-velociraptor.ps1
+++ b/Vagrant/scripts/install-velociraptor.ps1
@@ -32,7 +32,7 @@ If (-not(Test-Path $velociraptorLogFile) -or ($Update -eq $true)) {
   Invoke-WebRequest -Uri "$velociraptorDownloadUrl" -OutFile $velociraptorMSIPath
   Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Installing Velociraptor..."
   Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/i $velociraptorMSIPath /quiet /qn /norestart /log $velociraptorLogFile" -wait
-  Copy-Item "c:\vagrant\resources\velociraptor\Velociraptor.config.yaml" "C:\Program Files\Velociraptor"
+  Copy-Item "c:\vagrant\resources\velociraptor\Velociraptor.config.yaml" "C:\Program Files\Velociraptor\client.config.yaml"
   Restart-Service Velociraptor
   Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Velociraptor successfully installed!"
 } Else {


### PR DESCRIPTION
The Velociraptor service is currently installed to accept its client configuration from `C:\Program Files\Velociraptor\client.config.yaml` by default and doesn't read the configuration file as copied (`Velociraptor.config.yaml`). This PR adjusts the config to be copied to Velociraptor's default configuration location, thereby overwriting the default config from the installation with the appropriate one.