### PR TITLE
Fix Suricata query to sort by count desc

### DIFF
--- a/Vagrant/resources/splunk_server/logger_dashboard.xml
+++ b/Vagrant/resources/splunk_server/logger_dashboard.xml
@@ -50,7 +50,7 @@
       <title>Top Suricata Network Alerts</title>
       <table>
         <search>
-          <query>index=suricata | stats values(src_ip) count by alert.signature, alert.signature_id</query>
+          <query>index=suricata | stats values(src_ip) as src_ip count by alert.signature, alert.signature_id | sort -count</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
           <sampleRatio>1</sampleRatio>


### PR DESCRIPTION
The *Top Suricata Network Alerts* panel does not sort by count descending as suggested by the panel name. This PR adds `| sort -count` to correct that and adjusts `values(src_ip)` to `values(src_ip) as src_ip` to sorta clean up the column name.